### PR TITLE
Proper credit attribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,3 +277,5 @@ keypoints, scores, descriptors = pycolmap.extract_sift(img)
 - [ ] Add documentation
 - [ ] Add more detailed examples
 - [ ] Add unit tests for reconstruction bindings
+
+Created and maintained by [Mihai Dusmanu](https://github.com/mihaidusmanu/), [Philipp Lindenberger](https://github.com/Phil26AT), [John Lambert](https://github.com/johnwlambert), [Paul-Edouard Sarlin](https://github.com/Skydes), and other contributors.

--- a/estimators/absolute_pose.cc
+++ b/estimators/absolute_pose.cc
@@ -1,33 +1,4 @@
-// Copyright (c) 2018, ETH Zurich and UNC Chapel Hill.
-// All rights reserved.
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are met:
-//
-//     * Redistributions of source code must retain the above copyright
-//       notice, this list of conditions and the following disclaimer.
-//
-//     * Redistributions in binary form must reproduce the above copyright
-//       notice, this list of conditions and the following disclaimer in the
-//       documentation and/or other materials provided with the distribution.
-//
-//     * Neither the name of ETH Zurich and UNC Chapel Hill nor the names of
-//       its contributors may be used to endorse or promote products derived
-//       from this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-// POSSIBILITY OF SUCH DAMAGE.
-//
-// Author: Johannes L. Schoenberger (jsch at inf.ethz.ch)
+// Authors: Mihai-Dusmanu (mihaidusmanu), Paul-Edouard Sarlin (skydes)
 
 #include <iostream>
 #include <fstream>

--- a/estimators/essential_matrix.cc
+++ b/estimators/essential_matrix.cc
@@ -1,33 +1,4 @@
-// Copyright (c) 2018, ETH Zurich and UNC Chapel Hill.
-// All rights reserved.
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are met:
-//
-//     * Redistributions of source code must retain the above copyright
-//       notice, this list of conditions and the following disclaimer.
-//
-//     * Redistributions in binary form must reproduce the above copyright
-//       notice, this list of conditions and the following disclaimer in the
-//       documentation and/or other materials provided with the distribution.
-//
-//     * Neither the name of ETH Zurich and UNC Chapel Hill nor the names of
-//       its contributors may be used to endorse or promote products derived
-//       from this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-// POSSIBILITY OF SUCH DAMAGE.
-//
-// Author: Johannes L. Schoenberger (jsch at inf.ethz.ch)
+// Authors: Mihai-Dusmanu (mihaidusmanu), Paul-Edouard Sarlin (skydes)
 
 #include <iostream>
 #include <fstream>

--- a/estimators/fundamental_matrix.cc
+++ b/estimators/fundamental_matrix.cc
@@ -1,33 +1,4 @@
-// Copyright (c) 2018, ETH Zurich and UNC Chapel Hill.
-// All rights reserved.
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are met:
-//
-//     * Redistributions of source code must retain the above copyright
-//       notice, this list of conditions and the following disclaimer.
-//
-//     * Redistributions in binary form must reproduce the above copyright
-//       notice, this list of conditions and the following disclaimer in the
-//       documentation and/or other materials provided with the distribution.
-//
-//     * Neither the name of ETH Zurich and UNC Chapel Hill nor the names of
-//       its contributors may be used to endorse or promote products derived
-//       from this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-// POSSIBILITY OF SUCH DAMAGE.
-//
-// Author: Johannes L. Schoenberger (jsch at inf.ethz.ch)
+// Authors: Mihai-Dusmanu (mihaidusmanu), Paul-Edouard Sarlin (skydes)
 
 #include <iostream>
 #include <fstream>

--- a/estimators/generalized_absolute_pose.cc
+++ b/estimators/generalized_absolute_pose.cc
@@ -1,3 +1,5 @@
+// Authors: Mihai-Dusmanu (mihaidusmanu), Paul-Edouard Sarlin (skydes)
+
 #include <iostream>
 #include <fstream>
 

--- a/estimators/homography.cc
+++ b/estimators/homography.cc
@@ -1,3 +1,5 @@
+// Authors: John Lambert (johnwlambert), Paul-Edouard Sarlin (skydes)
+
 #include <iostream>
 #include <fstream>
 

--- a/estimators/two_view_geometry.cc
+++ b/estimators/two_view_geometry.cc
@@ -1,3 +1,4 @@
+// Authors: John Lambert (johnwlambert), Paul-Edouard Sarlin (skydes)
 
 #include <iostream>
 #include <fstream>

--- a/helpers.h
+++ b/helpers.h
@@ -1,3 +1,5 @@
+// Author: Philipp Lindenberger (Phil26AT)
+
 #pragma once
 
 #include <pybind11/embed.h>

--- a/homography_decomposition.cc
+++ b/homography_decomposition.cc
@@ -1,3 +1,5 @@
+// Author: Adi Singh (adisingh50)
+
 #include <iostream>
 #include <fstream>
 

--- a/log_exceptions.h
+++ b/log_exceptions.h
@@ -1,3 +1,5 @@
+// Author: Philipp Lindenberger (Phil26AT)
+
 #pragma once
 #include <exception>
 #include <sstream>

--- a/package/build-wheels-linux.sh
+++ b/package/build-wheels-linux.sh
@@ -5,6 +5,8 @@
 # and http://ceres-solver.org/installation.html (Ceres)
 # However, the OS is centOS 7, instead of Ubuntu.
 
+# Author: John Lambert (johnwlambert)
+
 uname -a
 echo "Current CentOS Version:"
 cat /etc/centos-release

--- a/package/build-wheels-macos.sh
+++ b/package/build-wheels-macos.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+# Author: John Lambert (johnwlambert)
+
 set -x -e
 
 function retry {

--- a/pipeline.cc
+++ b/pipeline.cc
@@ -1,3 +1,5 @@
+// Author: Paul-Edouard Sarlin (skydes)
+
 #include "colmap/base/reconstruction.h"
 #include "colmap/base/image_reader.h"
 #include "colmap/base/camera_models.h"

--- a/reconstruction/camera.cc
+++ b/reconstruction/camera.cc
@@ -1,3 +1,5 @@
+// Author: Philipp Lindenberger (Phil26AT)
+
 #include "colmap/base/image.h"
 #include "colmap/util/misc.h"
 #include "colmap/util/types.h"

--- a/reconstruction/image.cc
+++ b/reconstruction/image.cc
@@ -1,3 +1,5 @@
+// Author: Philipp Lindenberger (Phil26AT)
+
 #include "colmap/base/image.h"
 #include "colmap/util/misc.h"
 #include "colmap/util/types.h"

--- a/reconstruction/point2D.cc
+++ b/reconstruction/point2D.cc
@@ -1,3 +1,5 @@
+// Author: Philipp Lindenberger (Phil26AT)
+
 #include "colmap/base/point2d.h"
 #include "colmap/util/misc.h"
 #include "colmap/util/types.h"

--- a/reconstruction/point3D.cc
+++ b/reconstruction/point3D.cc
@@ -1,3 +1,5 @@
+// Author: Philipp Lindenberger (Phil26AT)
+
 #include "colmap/base/point3d.h"
 #include "colmap/util/misc.h"
 #include "colmap/util/types.h"

--- a/reconstruction/reconstruction.cc
+++ b/reconstruction/reconstruction.cc
@@ -1,3 +1,5 @@
+// Author: Philipp Lindenberger (Phil26AT)
+
 #include "colmap/base/reconstruction.h"
 #include "colmap/base/camera_models.h"
 #include "colmap/base/projection.h"

--- a/reconstruction/track.cc
+++ b/reconstruction/track.cc
@@ -1,3 +1,5 @@
+// Author: Philipp Lindenberger (Phil26AT)
+
 #include "colmap/base/track.h"
 #include "colmap/util/misc.h"
 #include "colmap/util/types.h"

--- a/reconstruction/utils.cc
+++ b/reconstruction/utils.cc
@@ -1,3 +1,5 @@
+// Author: Philipp Lindenberger (Phil26AT)
+
 #include "colmap/base/camera_models.h"
 #include "colmap/base/projection.h"
 #include "colmap/base/reconstruction.h"

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+""" Author: Mihai-Dusmanu (mihaidusmanu) """
+
 import os
 import re
 import sys

--- a/sift.cc
+++ b/sift.cc
@@ -1,3 +1,5 @@
+// Author: Mihai-Dusmanu (mihaidusmanu)
+
 #include <pybind11/pybind11.h>
 #include <pybind11/numpy.h>
 

--- a/transformations.cc
+++ b/transformations.cc
@@ -1,33 +1,4 @@
-// Copyright (c) 2018, ETH Zurich and UNC Chapel Hill.
-// All rights reserved.
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are met:
-//
-//     * Redistributions of source code must retain the above copyright
-//       notice, this list of conditions and the following disclaimer.
-//
-//     * Redistributions in binary form must reproduce the above copyright
-//       notice, this list of conditions and the following disclaimer in the
-//       documentation and/or other materials provided with the distribution.
-//
-//     * Neither the name of ETH Zurich and UNC Chapel Hill nor the names of
-//       its contributors may be used to endorse or promote products derived
-//       from this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-// POSSIBILITY OF SUCH DAMAGE.
-//
-// Author: Johannes L. Schoenberger (jsch at inf.ethz.ch)
+// Author: Philipp Lindenberger (Phil26AT)
 
 #include "colmap/base/similarity_transform.h"
 #include "colmap/base/warp.h"


### PR DESCRIPTION
It seems that GitHub does not track well contributors when a PR is squashed or a file is moved. At the very least we should indicate who wrote each file and can help maintaining it. Let me know if you have a better way of doing so.

cc @mihaidusmanu @Phil26AT @johnwlambert