### PR TITLE
Release the GIL in estimators

### DIFF
--- a/estimators/absolute_pose.cc
+++ b/estimators/absolute_pose.cc
@@ -34,7 +34,8 @@ py::dict absolute_pose_estimation(
     // Failure output dictionary.
     py::dict failure_dict;
     failure_dict["success"] = false;
-    //
+    py::gil_scoped_release release;
+
     // Absolute pose estimation.
     Eigen::Vector4d qvec;
     Eigen::Vector3d tvec;
@@ -61,6 +62,7 @@ py::dict absolute_pose_estimation(
     }
 
     // Success output dictionary.
+    py::gil_scoped_acquire acquire;
     py::dict success_dict;
     success_dict["success"] = true;
     success_dict["qvec"] = qvec;
@@ -120,6 +122,7 @@ py::dict pose_refinement(
     // Failure output dictionary.
     py::dict failure_dict;
     failure_dict["success"] = false;
+    py::gil_scoped_release release;
 
     // Absolute pose estimation.
     Eigen::Vector4d qvec_refined = qvec;
@@ -145,6 +148,7 @@ py::dict pose_refinement(
     }
 
     // Success output dictionary.
+    py::gil_scoped_acquire acquire;
     py::dict success_dict;
     success_dict["success"] = true;
     success_dict["qvec"] = qvec_refined;

--- a/estimators/essential_matrix.cc
+++ b/estimators/essential_matrix.cc
@@ -36,6 +36,7 @@ py::dict essential_matrix_estimation(
     // Failure output dictionary.
     py::dict failure_dict;
     failure_dict["success"] = false;
+    py::gil_scoped_release release;
 
     // Image to world.
     std::vector<Eigen::Vector2d> world_points2D1;
@@ -102,6 +103,7 @@ py::dict essential_matrix_estimation(
     }
 
     // Success output dictionary.
+    py::gil_scoped_acquire acquire;
     py::dict success_dict;
     success_dict["success"] = true;
     success_dict["E"] = E;

--- a/estimators/fundamental_matrix.cc
+++ b/estimators/fundamental_matrix.cc
@@ -31,7 +31,7 @@ py::dict fundamental_matrix_estimation(
     // Failure output dictionary.
     py::dict failure_dict;
     failure_dict["success"] = false;
-
+    py::gil_scoped_release release;
 
     LORANSAC<
         FundamentalMatrixSevenPointEstimator,
@@ -61,6 +61,7 @@ py::dict fundamental_matrix_estimation(
     }
 
     // Success output dictionary.
+    py::gil_scoped_acquire acquire;
     py::dict success_dict;
     success_dict["success"] = true;
     success_dict["F"] = F;

--- a/estimators/generalized_absolute_pose.cc
+++ b/estimators/generalized_absolute_pose.cc
@@ -288,6 +288,7 @@ py::dict rig_absolute_pose_estimation(
     // Failure output dictionary.
     py::dict failure_dict;
     failure_dict["success"] = false;
+    py::gil_scoped_release release;
 
     std::vector<GP3PEstimator::X_t> points2D_rig;
     std::vector<Eigen::Vector3d> points3D_all;
@@ -361,6 +362,7 @@ py::dict rig_absolute_pose_estimation(
         }
     }
 
+    py::gil_scoped_acquire acquire;
     py::dict success_dict;
     success_dict["success"] = true;
     success_dict["qvec"] = qvec;

--- a/estimators/homography.cc
+++ b/estimators/homography.cc
@@ -31,6 +31,7 @@ py::dict homography_matrix_estimation(
     // Failure output dictionary.
     py::dict failure_dict;
     failure_dict["success"] = false;
+    py::gil_scoped_release release;
 
     // Estimate planar or panoramic model.
     LORANSAC<
@@ -61,6 +62,7 @@ py::dict homography_matrix_estimation(
     }
 
     // Success output dictionary.
+    py::gil_scoped_acquire acquire;
     py::dict success_dict;
     success_dict["success"] = true;
     success_dict["H"] = H;


### PR DESCRIPTION
This PR releases the Python GIL in the estimators. This speeds up multi-threaded computations. [Numpy also does this.](https://iotespresso.com/numpy-releases-gil-what-does-that-mean/)