### PR TITLE
Improve the Reconstruction interface

### DIFF
--- a/reconstruction/camera.cc
+++ b/reconstruction/camera.cc
@@ -109,8 +109,11 @@ void init_camera(py::module& m) {
         .def("params_info", &Camera::ParamsInfo,
              "Get human-readable information about the parameter vector ordering.")
         .def("num_params", &Camera::NumParams, "Number of raw camera parameters.")
-        .def_property("params", overload_cast_<>()(&Camera::Params), &Camera::SetParams,
-                      "Camera parameters.")
+        .def_property(
+            "params",
+            [](Camera& self) {return Eigen::Map<Eigen::VectorXd>(self.ParamsData(), self.NumParams());},
+            &Camera::SetParams,
+            "Camera parameters.")
         .def("params_to_string", &Camera::ParamsToString,
              "Concatenate parameters as comma-separated list.")
         .def("set_params_from_string", &Camera::SetParamsFromString,

--- a/reconstruction/image.cc
+++ b/reconstruction/image.cc
@@ -84,7 +84,7 @@ void init_image(py::module& m) {
              py::arg("name") = "", py::arg("points2D") = std::vector<Point2D>(),
              py::arg("tvec") = Eigen::Vector3d(0.0, 0.0, 0.0),
              py::arg("qvec") = Eigen::Vector4d(1.0, 0.0, 0.0, 0.0),
-             py::arg("camera_id_id") = kInvalidCameraId, py::arg("id") = kInvalidImageId)
+             py::arg("camera_id") = kInvalidCameraId, py::arg("id") = kInvalidImageId)
         .def_property("image_id", &Image::ImageId, &Image::SetImageId,
                       "Unique identifier of image.")
         .def_property(

--- a/reconstruction/reconstruction.cc
+++ b/reconstruction/reconstruction.cc
@@ -170,7 +170,8 @@ void init_reconstruction(py::module& m) {
             "Add new image. If Image.IsRegistered()==true, either throw "
             "if check_not_registered, or register image also in reconstr.")
         .def("add_point3D", &Reconstruction::AddPoint3D,
-             "Add new 3D object, and return its unique ID.")
+             "Add new 3D object, and return its unique ID.",
+             py::arg("xyz"), py::arg("track"), py::arg("color") = Eigen::Vector3ub::Zero())
         .def("add_observation", &Reconstruction::AddObservation,
              "Add observation to existing 3D point.")
         .def("merge_points3D", &Reconstruction::MergePoints3D,


### PR DESCRIPTION
- `Camera.params` now returns an array instead of a list
- typo: `camera_id_id` -> `camera_id`
- optional color when creating a Point3D (copy C++ default)