### PR TITLE
Add mutable camera, image and point3D functions

### DIFF
--- a/reconstruction/reconstruction.cc
+++ b/reconstruction/reconstruction.cc
@@ -130,6 +130,12 @@ void init_reconstruction(py::module& m) {
         .def("num_reg_images", &Reconstruction::NumRegImages)
         .def("num_points3D", &Reconstruction::NumPoints3D)
         .def("num_image_pairs", &Reconstruction::NumImagePairs)
+        .def("camera_mutable", py::overload_cast<colmap::camera_t>(&Reconstruction::Camera),
+             py::return_value_policy::reference)
+        .def("image_mutable", py::overload_cast<colmap::image_t>(&Reconstruction::Image),
+             py::return_value_policy::reference)
+        .def("point3D_mutable", py::overload_cast<colmap::point3D_t>(&Reconstruction::Point3D),
+             py::return_value_policy::reference)
         .def_property_readonly("images", &Reconstruction::Images,
                                py::return_value_policy::reference)
         .def_property_readonly("image_pairs", &Reconstruction::ImagePairs)


### PR DESCRIPTION
Hi, I found that getting a point3D is not allowed if I have a point3D_id. Thus, I add three functions about the point3D, camera and image, which are mutable functions corresponding to the `reconstruction.h` file in **Colmap**. Thanks.