### PR TITLE
Bump version to v0.4.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ class CMakeBuild(build_ext):
 
 setup(
     name='pycolmap',
-    version='0.3.0',
+    version='0.4.0',
     author='Mihai Dusmanu',
     author_email='mihai.dusmanu@inf.ethz.ch',
     description='COLMAP bindings',


### PR DESCRIPTION
- So far, we've been incrementing the release version before each release.
- This goes against standard practice - we should instead increment it after each release, such that downstream dependencies can already require the current release tag of master until it is available in pypi.