### PR TITLE
Add aligned allocator for ListPoint2D

### DIFF
--- a/reconstruction/point2D.cc
+++ b/reconstruction/point2D.cc
@@ -1,5 +1,8 @@
 // Author: Philipp Lindenberger (Phil26AT)
 
+// Use Eigens aligned allocator for vectors
+#include<Eigen/StdVector>
+
 #include "colmap/base/point2d.h"
 #include "colmap/util/misc.h"
 #include "colmap/util/types.h"
@@ -19,7 +22,8 @@ using namespace pybind11::literals;
 template <typename... Args>
 using overload_cast_ = pybind11::detail::overload_cast_impl<Args...>;
 
-PYBIND11_MAKE_OPAQUE(std::vector<class Point2D>);
+using vector_Point2D = std::vector<class colmap::Point2D, Eigen::aligned_allocator<colmap::Point2D>>;
+PYBIND11_MAKE_OPAQUE(vector_Point2D);
 
 std::string PrintPoint2D(const colmap::Point2D& p2D) {
     std::stringstream ss;
@@ -30,8 +34,8 @@ std::string PrintPoint2D(const colmap::Point2D& p2D) {
 }
 
 void init_point2D(py::module& m) {
-    py::bind_vector<std::vector<class Point2D>>(m, "ListPoint2D")
-        .def("__repr__", [](const std::vector<class Point2D>& self) {
+    py::bind_vector<vector_Point2D>(m, "ListPoint2D")
+        .def("__repr__", [](const vector_Point2D& self) {
             std::string repr = "[";
             bool is_first = true;
             for (auto& p2D : self) {


### PR DESCRIPTION
Problem: COLMAP uses [Eigens aligned allocator](https://eigen.tuxfamily.org/dox/group__TopicStlContainers.html) for vectors of [Point2D](https://github.com/colmap/colmap/blob/dev/src/base/point2d.h#L96).

This PR ensures that `pycolmap.ListPoint2D` also uses this aligned allocator (previously caused `MaxRecursionError` in some cases).