### PR TITLE
Update includes to match new COLMAP structure

### DIFF
--- a/estimators/essential_matrix.cc
+++ b/estimators/essential_matrix.cc
@@ -4,8 +4,8 @@
 #include <fstream>
 
 #include "colmap/base/camera.h"
-#include "colmap/base/essential_matrix.h"
-#include "colmap/base/pose.h"
+#include "colmap/geometry/essential_matrix.h"
+#include "colmap/geometry/pose.h"
 #include "colmap/estimators/essential_matrix.h"
 #include "colmap/optim/loransac.h"
 #include "colmap/util/random.h"

--- a/estimators/generalized_absolute_pose.cc
+++ b/estimators/generalized_absolute_pose.cc
@@ -4,9 +4,9 @@
 #include <fstream>
 
 #include "colmap/base/camera.h"
-#include "colmap/base/pose.h"
-#include "colmap/base/projection.h"
-#include "colmap/base/similarity_transform.h"
+#include "colmap/geometry/pose.h"
+#include "colmap/geometry/projection.h"
+#include "colmap/geometry/similarity_transform.h"
 #include "colmap/optim/ransac.h"
 #include "colmap/util/random.h"
 #include "colmap/util/misc.h"

--- a/estimators/two_view_geometry.cc
+++ b/estimators/two_view_geometry.cc
@@ -4,7 +4,7 @@
 #include <fstream>
 
 #include "colmap/base/camera.h"
-#include "colmap/base/pose.h"
+#include "colmap/geometry/pose.h"
 #include "colmap/estimators/two_view_geometry.h"
 #include "colmap/optim/loransac.h"
 #include "colmap/util/random.h"

--- a/homography_decomposition.cc
+++ b/homography_decomposition.cc
@@ -3,7 +3,7 @@
 #include <iostream>
 #include <fstream>
 
-#include "colmap/base/homography_matrix.h"
+#include "colmap/geometry/homography_matrix.h"
 
 using namespace colmap;
 

--- a/main.cc
+++ b/main.cc
@@ -4,7 +4,7 @@
 
 namespace py = pybind11;
 
-#include <colmap/base/pose.h>
+#include <colmap/geometry/pose.h>
 
 #include "estimators/absolute_pose.cc"
 #include "estimators/generalized_absolute_pose.cc"

--- a/pipeline/extract_features.cc
+++ b/pipeline/extract_features.cc
@@ -1,7 +1,7 @@
 // Author: Philipp Lindenberger (Phil26AT)
 
-#include "colmap/base/camera_models.h"
-#include "colmap/base/image_reader.h"
+#include "colmap/camera/models.h"
+#include "colmap/image/reader.h"
 #include "colmap/base/reconstruction.h"
 #include "colmap/controllers/incremental_mapper.h"
 #include "colmap/exe/feature.h"

--- a/pipeline/images.cc
+++ b/pipeline/images.cc
@@ -1,9 +1,9 @@
 // Author: Paul-Edouard Sarlin (skydes)
 
-#include "colmap/base/camera_models.h"
-#include "colmap/base/image_reader.h"
+#include "colmap/camera/models.h"
+#include "colmap/image/reader.h"
 #include "colmap/base/reconstruction.h"
-#include "colmap/base/undistortion.h"
+#include "colmap/image/undistortion.h"
 #include "colmap/controllers/incremental_mapper.h"
 #include "colmap/exe/feature.h"
 #include "colmap/exe/sfm.h"

--- a/pipeline/match_features.cc
+++ b/pipeline/match_features.cc
@@ -1,7 +1,7 @@
 // Author: Philipp Lindenberger (Phil26AT)
 
-#include "colmap/base/camera_models.h"
-#include "colmap/base/image_reader.h"
+#include "colmap/camera/models.h"
+#include "colmap/image/reader.h"
 #include "colmap/base/reconstruction.h"
 #include "colmap/controllers/incremental_mapper.h"
 #include "colmap/exe/feature.h"

--- a/pipeline/mvs.cc
+++ b/pipeline/mvs.cc
@@ -1,5 +1,5 @@
-#include "colmap/base/camera_models.h"
-#include "colmap/base/image_reader.h"
+#include "colmap/camera/models.h"
+#include "colmap/image/reader.h"
 #include "colmap/base/reconstruction.h"
 #include "colmap/controllers/incremental_mapper.h"
 #include "colmap/exe/feature.h"

--- a/pipeline/sfm.cc
+++ b/pipeline/sfm.cc
@@ -1,7 +1,7 @@
 // Author: Paul-Edouard Sarlin (skydes)
 
 #include "colmap/exe/sfm.h"
-#include "colmap/base/camera_models.h"
+#include "colmap/camera/models.h"
 #include "colmap/base/reconstruction.h"
 #include "colmap/controllers/incremental_mapper.h"
 #include "colmap/util/misc.h"

--- a/reconstruction/reconstruction.cc
+++ b/reconstruction/reconstruction.cc
@@ -1,7 +1,7 @@
 // Author: Philipp Lindenberger (Phil26AT)
 
 #include "colmap/base/reconstruction.h"
-#include "colmap/base/camera_models.h"
+#include "colmap/camera/models.h"
 #include "colmap/base/projection.h"
 #include "colmap/util/misc.h"
 #include "colmap/util/ply.h"

--- a/reconstruction/reconstruction.cc
+++ b/reconstruction/reconstruction.cc
@@ -2,7 +2,7 @@
 
 #include "colmap/base/reconstruction.h"
 #include "colmap/camera/models.h"
-#include "colmap/base/projection.h"
+#include "colmap/geometry/projection.h"
 #include "colmap/util/misc.h"
 #include "colmap/util/ply.h"
 #include "colmap/util/types.h"

--- a/reconstruction/utils.cc
+++ b/reconstruction/utils.cc
@@ -1,6 +1,6 @@
 // Author: Philipp Lindenberger (Phil26AT)
 
-#include "colmap/base/camera_models.h"
+#include "colmap/camera/models.h"
 #include "colmap/base/projection.h"
 #include "colmap/base/reconstruction.h"
 #include "colmap/util/misc.h"

--- a/reconstruction/utils.cc
+++ b/reconstruction/utils.cc
@@ -1,7 +1,7 @@
 // Author: Philipp Lindenberger (Phil26AT)
 
 #include "colmap/camera/models.h"
-#include "colmap/base/projection.h"
+#include "colmap/geometry/projection.h"
 #include "colmap/base/reconstruction.h"
 #include "colmap/util/misc.h"
 #include "colmap/util/ply.h"

--- a/transformations.cc
+++ b/transformations.cc
@@ -1,6 +1,6 @@
 // Author: Philipp Lindenberger (Phil26AT)
 
-#include "colmap/base/similarity_transform.h"
+#include "colmap/geometry/similarity_transform.h"
 #include "colmap/image/warp.h"
 #include "colmap/camera/models.h"
 

--- a/transformations.cc
+++ b/transformations.cc
@@ -1,8 +1,8 @@
 // Author: Philipp Lindenberger (Phil26AT)
 
 #include "colmap/base/similarity_transform.h"
-#include "colmap/base/warp.h"
-#include "colmap/base/camera_models.h"
+#include "colmap/image/warp.h"
+#include "colmap/camera/models.h"
 
 using namespace colmap;
 


### PR DESCRIPTION
See Issue https://github.com/colmap/pycolmap/issues/153

In the main Colmap repo, a lot of file / folder structures were moved. Building pycolmap with the latest colmap repository is not possible anymore, as the include paths don't match up. During building you get errors like "colmap/base/xx.h No such file or directory"

See: https://github.com/colmap/colmap/commit/3c38248720e62efa8adeef94b156bddf48781a72 and https://github.com/colmap/colmap/commit/91068eac3f1ba0f871d0ea96e536dffaeda76630

I fixed the include paths in this PR. I did test the changes by running the build with `pip install .` and with these changes, pycolmap can be build with the latest colmap repository again.