### PR TITLE
Fix the CI

### DIFF
--- a/package/build-wheels-macos.sh
+++ b/package/build-wheels-macos.sh
@@ -15,6 +15,7 @@ echo "Number of logical CPUs is: ${NUM_LOGICAL_CPUS}"
 
 # Updating requires Xcode 14.0, which cannot be installed on macOS 11.
 brew remove swiftlint
+brew remove node@18
 
 brew update
 brew upgrade


### PR DESCRIPTION
```
 ==> Upgrading node@18
  18.17.1 -> 18.18.0 

 Error: The `brew link` step did not complete successfully
The formula built, but is not symlinked into /usr/local
Could not symlink lib/node_modules/npm/bin/npm.ps1
Target /usr/local/lib/node_modules/npm/bin/npm.ps1
already exists. You may want to remove it:
  rm '/usr/local/lib/node_modules/npm/bin/npm.ps1'

To force the link and overwrite all conflicting files:
  brew link --overwrite node@18

To list all files that would be deleted:
  brew link --overwrite --dry-run node@18
````