### PR TITLE
Fix failing MacOS 11 CI

### DIFF
--- a/.github/workflows/build-new.yml
+++ b/.github/workflows/build-new.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ macos-11, macos-12 ]
+        os: [ macos-11, macos-12, macos-13 ]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/package/build-wheels-macos.sh
+++ b/package/build-wheels-macos.sh
@@ -18,8 +18,6 @@ brew remove swiftlint
 brew remove node@18
 
 brew update
-brew upgrade
-brew install wget cmake
 
 for PYTHON_VERSION in ${PYTHON_VERSIONS[@]}; do
     brew install --force "python@${PYTHON_VERSION}"
@@ -28,6 +26,7 @@ done
 
 brew install \
     git \
+    wget \
     cmake \
     eigen \
     freeimage \
@@ -38,16 +37,11 @@ brew install \
     suite-sparse \
     ceres-solver \
     glew \
-    cgal \
     sqlite3 \
     libomp \
     llvm \
     boost \
     lz4
-
-brew info gcc
-brew upgrade gcc
-brew info gcc
 
 # Install Boost
 #mkdir -p boost


### PR DESCRIPTION
MacOS 11 times-out because homebrew builds many packages from scratch, so we skip unnecessary upgrades