### PR TITLE
Use reference_internal for reconstruction data

### DIFF
--- a/pycolmap/scene/reconstruction.h
+++ b/pycolmap/scene/reconstruction.h
@@ -110,15 +110,16 @@ void BindReconstruction(py::module& m) {
       .def("num_reg_images", &Reconstruction::NumRegImages)
       .def("num_points3D", &Reconstruction::NumPoints3D)
       .def("num_image_pairs", &Reconstruction::NumImagePairs)
-      .def_property_readonly(
-          "images", &Reconstruction::Images, py::return_value_policy::reference)
+      .def_property_readonly("images",
+                             &Reconstruction::Images,
+                             py::return_value_policy::reference_internal)
       .def_property_readonly("image_pairs", &Reconstruction::ImagePairs)
       .def_property_readonly("cameras",
                              &Reconstruction::Cameras,
-                             py::return_value_policy::reference)
+                             py::return_value_policy::reference_internal)
       .def_property_readonly("points3D",
                              &Reconstruction::Points3D,
-                             py::return_value_policy::reference)
+                             py::return_value_policy::reference_internal)
       .def("point3D_ids", &Reconstruction::Point3DIds)
       .def("reg_image_ids", &Reconstruction::RegImageIds)
       .def("exists_camera", &Reconstruction::ExistsCamera)


### PR DESCRIPTION
Fixes https://github.com/colmap/pycolmap/issues/212

Drawback: keeps the entire reconstruction object in memory until any Python reference to any child object image/camera/point3D is deleted.

Minimal example:
```python
import pycolmap
import numpy as np
import gc

reconstruction = pycolmap.Reconstruction()
i = reconstruction.add_point3D(
    xyz=np.array([0, 0, 0]),
    color=np.array([0, 0, 0], dtype=np.uint8),
    track=pycolmap.Track(),
)
p = reconstruction.points3D[i]
print(p.summary())

del reconstruction
gc.collect()

# allocate most of the memory to a new object
x = np.random.rand(3000,10000,100)

assert np.all(p.color == np.zeros(3))
```
