### PR TITLE
Add to __doc__ the type and default values of each option

### DIFF
--- a/pycolmap/estimators/absolute_pose.h
+++ b/pycolmap/estimators/absolute_pose.h
@@ -120,7 +120,7 @@ void BindAbsolutePoseEstimator(py::module& m) {
                          &AbsolutePoseEstimationOptions::max_focal_length_ratio)
           .def_readwrite("ransac",
                          &AbsolutePoseEstimationOptions::ransac_options);
-  make_dataclass(PyEstimationOptions);
+  MakeDataclass(PyEstimationOptions);
   auto est_options =
       PyEstimationOptions().cast<AbsolutePoseEstimationOptions>();
 
@@ -146,7 +146,7 @@ void BindAbsolutePoseEstimator(py::module& m) {
                          &AbsolutePoseRefinementOptions::refine_extra_params)
           .def_readwrite("print_summary",
                          &AbsolutePoseRefinementOptions::print_summary);
-  make_dataclass(PyRefinementOptions);
+  MakeDataclass(PyRefinementOptions);
   auto ref_options =
       PyRefinementOptions().cast<AbsolutePoseRefinementOptions>();
 

--- a/pycolmap/estimators/triangulation.h
+++ b/pycolmap/estimators/triangulation.h
@@ -61,7 +61,7 @@ void BindTriangulationEstimator(py::module& m) {
                          &EstimateTriangulationOptions::min_tri_angle)
           .def_readwrite("ransac",
                          &EstimateTriangulationOptions::ransac_options);
-  make_dataclass(PyTriangulationOptions);
+  MakeDataclass(PyTriangulationOptions);
   auto triangulation_options =
       PyTriangulationOptions().cast<EstimateTriangulationOptions>();
 

--- a/pycolmap/estimators/two_view_geometry.h
+++ b/pycolmap/estimators/two_view_geometry.h
@@ -65,7 +65,7 @@ void BindTwoViewGeometryEstimator(py::module& m) {
           .def_readwrite("multiple_models",
                          &TwoViewGeometryOptions::multiple_models)
           .def_readwrite("ransac", &TwoViewGeometryOptions::ransac_options);
-  make_dataclass(PyTwoViewGeometryOptions);
+  MakeDataclass(PyTwoViewGeometryOptions);
   auto tvg_options = PyTwoViewGeometryOptions().cast<TwoViewGeometryOptions>();
 
   py::enum_<TwoViewGeometry::ConfigurationType>(m,
@@ -82,6 +82,7 @@ void BindTwoViewGeometryEstimator(py::module& m) {
 
   auto PyTwoViewGeometry =
       py::class_<TwoViewGeometry>(m, "TwoViewGeometry")
+          .def(py::init<>())
           .def_readonly("config", &TwoViewGeometry::config)
           .def_readonly("E", &TwoViewGeometry::E)
           .def_readonly("F", &TwoViewGeometry::F)
@@ -94,7 +95,7 @@ void BindTwoViewGeometryEstimator(py::module& m) {
               })
           .def_readonly("tri_angle", &TwoViewGeometry::tri_angle)
           .def("invert", &TwoViewGeometry::Invert);
-  make_dataclass(PyTwoViewGeometry);
+  MakeDataclass(PyTwoViewGeometry);
 
   m.def(
       "estimate_calibrated_two_view_geometry",

--- a/pycolmap/helpers.h
+++ b/pycolmap/helpers.h
@@ -183,7 +183,7 @@ inline std::string CreateSummary(const T& self, bool write_type) {
 }
 
 template <typename T, typename... options>
-inline void make_dataclass(py::class_<T, options...> cls) {
+inline void MakeDataclass(py::class_<T, options...> cls) {
   cls.def("mergedict", &UpdateFromDict);
   cls.def("summary", &CreateSummary<T>, "write_type"_a = false);
   cls.def("todict", &ConvertToDict<T>);

--- a/pycolmap/helpers.h
+++ b/pycolmap/helpers.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include "colmap/util/string.h"
 #include "colmap/util/threading.h"
 #include "colmap/util/types.h"
 
@@ -183,7 +184,30 @@ inline std::string CreateSummary(const T& self, bool write_type) {
 }
 
 template <typename T, typename... options>
+void AddDefaultsToDocstrings(py::class_<T, options...> cls) {
+  auto obj = cls();
+  for (auto& handle : obj.attr("__dir__")()) {
+    const std::string attribute = py::str(handle);
+    const auto member = obj.attr(attribute.c_str());
+    if (attribute.find("__") == 0 ||
+        attribute.rfind("__") != std::string::npos ||
+        py::hasattr(member, "__func__")) {
+      continue;
+    }
+    auto prop = cls.attr(attribute.c_str());
+    const auto type_name = py::type::of(member).attr("__name__");
+    const std::string doc =
+        StringPrintf("%s (%s, default: %s)",
+                     py::str(prop.doc()).cast<std::string>().c_str(),
+                     type_name.template cast<std::string>().c_str(),
+                     py::str(member).cast<std::string>().c_str());
+    prop.doc() = py::str(doc);
+  }
+}
+
+template <typename T, typename... options>
 inline void MakeDataclass(py::class_<T, options...> cls) {
+  AddDefaultsToDocstrings(cls);
   cls.def("mergedict", &UpdateFromDict);
   cls.def("summary", &CreateSummary<T>, "write_type"_a = false);
   cls.def("todict", &ConvertToDict<T>);

--- a/pycolmap/optim/bindings.h
+++ b/pycolmap/optim/bindings.h
@@ -23,5 +23,5 @@ void BindOptim(py::module& m) {
                          &RANSACOptions::dyn_num_trials_multiplier)
           .def_readwrite("min_num_trials", &RANSACOptions::min_num_trials)
           .def_readwrite("max_num_trials", &RANSACOptions::max_num_trials);
-  make_dataclass(PyRANSACOptions);
+  MakeDataclass(PyRANSACOptions);
 }

--- a/pycolmap/pipeline/extract_features.h
+++ b/pycolmap/pipeline/extract_features.h
@@ -142,7 +142,7 @@ void BindExtractFeatures(py::module& m) {
           .def_readwrite("normalization",
                          &SEOpts::normalization,
                          "L1_ROOT or L2 descriptor normalization");
-  make_dataclass(PySiftExtractionOptions);
+  MakeDataclass(PySiftExtractionOptions);
   auto sift_extraction_options = PySiftExtractionOptions().cast<SEOpts>();
 
   /* PIPELINE */

--- a/pycolmap/pipeline/images.h
+++ b/pycolmap/pipeline/images.h
@@ -220,7 +220,7 @@ void BindImages(py::module& m) {
               "Optional path to an image file specifying a mask for all "
               "images. No features will be extracted in regions where the "
               "mask is black (pixel intensity value 0 in grayscale)");
-  make_dataclass(PyImageReaderOptions);
+  MakeDataclass(PyImageReaderOptions);
   auto reader_options = PyImageReaderOptions().cast<IROpts>();
 
   auto PyCopyType = py::enum_<CopyType>(m, "CopyType")
@@ -253,7 +253,7 @@ void BindImages(py::module& m) {
           .def_readwrite("roi_min_y", &UDOpts::roi_min_y)
           .def_readwrite("roi_max_x", &UDOpts::roi_max_x)
           .def_readwrite("roi_max_y", &UDOpts::roi_max_y);
-  make_dataclass(PyUndistortCameraOptions);
+  MakeDataclass(PyUndistortCameraOptions);
   auto undistort_options = PyUndistortCameraOptions().cast<UDOpts>();
 
   m.def("import_images",

--- a/pycolmap/pipeline/match_features.h
+++ b/pycolmap/pipeline/match_features.h
@@ -103,7 +103,7 @@ void BindMatchFeatures(py::module& m) {
                          &SMOpts::guided_matching,
                          "Whether to perform guided matching, if geometric "
                          "verification succeeds.");
-  make_dataclass(PySiftMatchingOptions);
+  MakeDataclass(PySiftMatchingOptions);
   auto sift_matching_options = PySiftMatchingOptions().cast<SMOpts>();
 
   using EMOpts = ExhaustiveMatchingOptions;
@@ -111,7 +111,7 @@ void BindMatchFeatures(py::module& m) {
       py::class_<ExhaustiveMatchingOptions>(m, "ExhaustiveMatchingOptions")
           .def(py::init<>())
           .def_readwrite("block_size", &EMOpts::block_size);
-  make_dataclass(PyExhaustiveMatchingOptions);
+  MakeDataclass(PyExhaustiveMatchingOptions);
   auto exhaustive_options = PyExhaustiveMatchingOptions().cast<EMOpts>();
 
   using SeqMOpts = SequentialMatchingOptions;
@@ -155,7 +155,7 @@ void BindMatchFeatures(py::module& m) {
           .def_readwrite("vocab_tree_path",
                          &SeqMOpts::vocab_tree_path,
                          "Path to the vocabulary tree.");
-  make_dataclass(PySequentialMatchingOptions);
+  MakeDataclass(PySequentialMatchingOptions);
   auto sequential_options = PySequentialMatchingOptions().cast<SeqMOpts>();
 
   using SpMOpts = SpatialMatchingOptions;
@@ -178,7 +178,7 @@ void BindMatchFeatures(py::module& m) {
                          &SpMOpts::max_distance,
                          "The maximum distance between the query and nearest "
                          "neighbor [meters].");
-  make_dataclass(PySpatialMatchingOptions);
+  MakeDataclass(PySpatialMatchingOptions);
   auto spatial_options = PySpatialMatchingOptions().cast<SpMOpts>();
 
   using VTMOpts = VocabTreeMatchingOptions;
@@ -217,7 +217,7 @@ void BindMatchFeatures(py::module& m) {
                             "vocab_tree_path required.");
             THROW_CHECK_FILE_EXISTS(self.vocab_tree_path);
           });
-  make_dataclass(PyVocabTreeMatchingOptions);
+  MakeDataclass(PyVocabTreeMatchingOptions);
   auto vocabtree_options = PyVocabTreeMatchingOptions().cast<VTMOpts>();
 
   auto verification_options =

--- a/pycolmap/pipeline/meshing.h
+++ b/pycolmap/pipeline/meshing.h
@@ -56,7 +56,7 @@ void BindMeshing(py::module& m) {
               "num_threads",
               &PoissonMOpts::num_threads,
               "The number of threads used for the Poisson reconstruction.");
-  make_dataclass(PyPoissonMeshingOptions);
+  MakeDataclass(PyPoissonMeshingOptions);
   auto poisson_options = PyPoissonMeshingOptions().cast<PoissonMOpts>();
 
   using DMOpts = mvs::DelaunayMeshingOptions;
@@ -114,7 +114,7 @@ void BindMeshing(py::module& m) {
                          &DMOpts::num_threads,
                          "The number of threads to use for reconstruction. "
                          "Default is all threads.");
-  make_dataclass(PyDelaunayMeshingOptions);
+  MakeDataclass(PyDelaunayMeshingOptions);
   auto delaunay_options = PyDelaunayMeshingOptions().cast<DMOpts>();
 
   m.def(

--- a/pycolmap/pipeline/mvs.h
+++ b/pycolmap/pipeline/mvs.h
@@ -192,7 +192,7 @@ void BindMVS(py::module& m) {
           .def_readwrite("write_consistency_graph",
                          &PMOpts::write_consistency_graph,
                          "Whether to write the consistency graph.");
-  make_dataclass(PyPatchMatchOptions);
+  MakeDataclass(PyPatchMatchOptions);
   auto patch_match_options = PyPatchMatchOptions().cast<PMOpts>();
 
   m.def("patch_match_stereo",
@@ -256,7 +256,7 @@ void BindMVS(py::module& m) {
                          &SFOpts::bounding_box,
                          "Bounding box Tuple[min, max]");
 
-  make_dataclass(PyStereoFusionOptions);
+  MakeDataclass(PyStereoFusionOptions);
   auto stereo_fusion_options = PyStereoFusionOptions().cast<SFOpts>();
 
   m.def("stereo_fusion",

--- a/pycolmap/pipeline/sfm.h
+++ b/pycolmap/pipeline/sfm.h
@@ -250,7 +250,7 @@ void BindSfM(py::module& m) {
                      "Options of the IncrementalTriangulator.")
       .def("get_mapper", &MapperOpts::Mapper)
       .def("get_triangulation", &MapperOpts::Triangulation);
-  make_dataclass(PyMapperOpts);
+  MakeDataclass(PyMapperOpts);
   auto mapper_options = PyMapperOpts().cast<MapperOpts>();
 
   using BAOpts = BundleAdjustmentOptions;
@@ -289,7 +289,7 @@ void BindSfM(py::module& m) {
           .def_readwrite("max_consecutive_nonmonotonic_steps",
                          &CSOpts::max_consecutive_nonmonotonic_steps)
           .def_readwrite("num_threads", &CSOpts::num_threads);
-  make_dataclass(PyCeresSolverOptions);
+  MakeDataclass(PyCeresSolverOptions);
   auto PyBundleAdjustmentOptions =
       py::class_<BAOpts>(m, "BundleAdjustmentOptions")
           .def(py::init<>())
@@ -327,7 +327,7 @@ void BindSfM(py::module& m) {
           .def_readwrite("solver_options",
                          &BAOpts::solver_options,
                          "Ceres-Solver options.");
-  make_dataclass(PyBundleAdjustmentOptions);
+  MakeDataclass(PyBundleAdjustmentOptions);
   auto ba_options = PyBundleAdjustmentOptions().cast<BAOpts>();
 
   m.def("triangulate_points",

--- a/pycolmap/scene/point3D.h
+++ b/pycolmap/scene/point3D.h
@@ -30,5 +30,5 @@ void BindPoint3D(py::module& m) {
           .def("__copy__", [](const Point3D& self) { return Point3D(self); })
           .def("__deepcopy__",
                [](const Point3D& self, py::dict) { return Point3D(self); });
-  make_dataclass(PyPoint3D);
+  MakeDataclass(PyPoint3D);
 }

--- a/pycolmap/sfm/incremental_mapper.h
+++ b/pycolmap/sfm/incremental_mapper.h
@@ -94,5 +94,5 @@ void BindIncrementalMapper(py::module& m) {
       .def_readwrite("image_selection_method",
                      &Opts::image_selection_method,
                      "Method to find and select next best image to register.");
-  make_dataclass(PyOpts);
+  MakeDataclass(PyOpts);
 }

--- a/pycolmap/sfm/incremental_triangulator.h
+++ b/pycolmap/sfm/incremental_triangulator.h
@@ -69,7 +69,7 @@ void BindIncrementalTriangulator(py::module& m) {
                      &Opts::max_extra_param,
                      "The threshold used to filter and ignore images with "
                      "degenerate intrinsics.");
-  make_dataclass(PyOpts);
+  MakeDataclass(PyOpts);
 
   py::class_<IncrementalTriangulator, std::shared_ptr<IncrementalTriangulator>>(
       m, "IncrementalTriangulator")


### PR DESCRIPTION
Example:
```
class IncrementalMapperOptions(pybind11_builtins.pybind11_object)
 |  Method resolution order:
 |      IncrementalMapperOptions
 |      pybind11_builtins.pybind11_object
 |      builtins.object
 |  ...
 |
 |  ----------------------------------------------------------------------
 |  Data descriptors defined here:
 |
 |  abs_pose_max_error
 |      Maximum reprojection error in absolute pose estimation. (float, default: 12.0)
 |
 |  abs_pose_min_inlier_ratio
 |      Minimum inlier ratio in absolute pose estimation. (float, default: 0.25)
 |
 |  abs_pose_min_num_inliers
 |      Minimum number of inliers in absolute pose estimation. (int, default: 30)
 |
 |  abs_pose_refine_extra_params
 |      Whether to estimate the extra parameters in absolute pose estimation. (bool, default: True)
 |
 |  abs_pose_refine_focal_length
 |      Whether to estimate the focal length in absolute pose estimation. (bool, default: True)
 |
 |  filter_max_reproj_error
 |      Maximum reprojection error in pixels for observations. (float, default: 4.0)
 |
 |  filter_min_tri_angle
 |      Minimum triangulation angle in degrees for stable 3D points. (float, default: 1.5)
 |
 |  fix_existing_images
 |      If reconstruction is provided as input, fix the existing image poses. (bool, default: False)
 |
 |  image_selection_method
 |      Method to find and select next best image to register. (ImageSelectionMethod, default: ImageSelectionMethod.MIN_UNCERTAINTY)
 |
 |  init_max_error
 |      Maximum error in pixels for two-view geometry estimation for initial image pair. (float, default: 4.0)
 |
 |  init_max_forward_motion
 |      Maximum forward motion for initial image pair. (float, default: 0.95)
 |
 |  init_max_reg_trials
 |      Maximum number of trials to use an image for initialization. (int, default: 2)
 |
 |  init_min_num_inliers
 |      Minimum number of inliers for initial image pair. (int, default: 100)
 |
 |  init_min_tri_angle
 |      Minimum triangulation angle for initial image pair. (float, default: 16.0)
 |
 |  local_ba_min_tri_angle
 |      Minimum triangulation for images to be chosen in local bundle adjustment. (float, default: 6.0)
```