### PR TITLE
Fix bug in Reconstruction.add_image

### DIFF
--- a/pycolmap/scene/reconstruction.h
+++ b/pycolmap/scene/reconstruction.h
@@ -137,25 +137,15 @@ void BindReconstruction(py::module& m) {
           "might be taken by the same camera.")
       .def(
           "add_image",
-          [](Reconstruction& self,
-             const class Image& image,
-             bool check_not_registered) {
+          [](Reconstruction& self, const class Image& image) {
             THROW_CHECK(!self.ExistsImage(image.ImageId()));
-            if (check_not_registered) {
-              THROW_CHECK(!image.IsRegistered());
-            }
             self.AddImage(image);
             if (image.IsRegistered()) {
               THROW_CHECK_NE(image.ImageId(), kInvalidImageId);
-              self.Image(image.ImageId())
-                  .SetRegistered(false);  // Set true in next line
-              self.RegisterImage(image.ImageId());
             }
           },
           "image"_a,
-          "check_not_registered"_a = false,
-          "Add new image. If Image.IsRegistered()==true, either throw "
-          "if check_not_registered, or register image also in reconstr.")
+          "Add a new image.")
       .def("add_point3D",
            &Reconstruction::AddPoint3D,
            "Add new 3D object, and return its unique ID.",


### PR DESCRIPTION
Since https://github.com/colmap/colmap/commit/67029ad21205fac3d149e06000c1e20bf4be1b80 `Reconstruction::AddImage` takes care of adding the image to the registered ids if needed, resulting in images being added twice when calling `add_image`.