### PR TITLE
Improve __repr__ for various objects

### DIFF
--- a/pycolmap/geometry/bindings.h
+++ b/pycolmap/geometry/bindings.h
@@ -19,6 +19,7 @@ void BindGeometry(py::module& m) {
   BindHomographyGeometry(m);
 
   py::class_<Eigen::Quaterniond>(m, "Rotation3d")
+      .def(py::init([]() { return Eigen::Quaterniond::Identity(); }))
       .def(py::init<const Eigen::Vector4d&>(), "xyzw"_a)
       .def(py::init<const Eigen::Matrix3d&>(), "rotmat"_a)
       .def(py::self * Eigen::Quaterniond())
@@ -33,6 +34,7 @@ void BindGeometry(py::module& m) {
         ss << "Rotation3d: " << self.coeffs();
         return ss.str();
       });
+  py::implicitly_convertible<py::array, Eigen::Quaterniond>();
 
   py::class_<Rigid3d>(m, "Rigid3d")
       .def(py::init<>())

--- a/pycolmap/geometry/bindings.h
+++ b/pycolmap/geometry/bindings.h
@@ -31,7 +31,7 @@ void BindGeometry(py::module& m) {
       .def("inverse", &Eigen::Quaterniond::inverse)
       .def("__repr__", [](const Eigen::Quaterniond& self) {
         std::stringstream ss;
-        ss << "Rotation3d: " << self.coeffs();
+        ss << "Rotation3d(quat_xyzw=[" << self.coeffs().transpose() << "])";
         return ss.str();
       });
   py::implicitly_convertible<py::array, Eigen::Quaterniond>();
@@ -48,7 +48,9 @@ void BindGeometry(py::module& m) {
       .def_static("interpolate", &InterpolateCameraPoses)
       .def("__repr__", [](const Rigid3d& self) {
         std::stringstream ss;
-        ss << "Rigid3d:\n" << self.ToMatrix();
+        ss << "Rigid3d("
+           << "quat_xyzw=[" << self.rotation.coeffs().transpose() << "], "
+           << "t=[" << self.translation.transpose() << "])";
         return ss.str();
       });
 
@@ -67,7 +69,10 @@ void BindGeometry(py::module& m) {
       .def("inverse", static_cast<Sim3d (*)(const Sim3d&)>(&Inverse))
       .def("__repr__", [](const Sim3d& self) {
         std::stringstream ss;
-        ss << "Sim3d:\n" << self.ToMatrix();
+        ss << "Sim3d("
+           << "scale=" << self.scale << ", "
+           << "quat_xyzw=[" << self.rotation.coeffs().transpose() << "], "
+           << "t=[" << self.translation.transpose() << "])";
         return ss.str();
       });
 }

--- a/pycolmap/geometry/bindings.h
+++ b/pycolmap/geometry/bindings.h
@@ -3,6 +3,7 @@
 #include "colmap/geometry/sim3.h"
 
 #include "pycolmap/geometry/homography_matrix.h"
+#include "pycolmap/helpers.h"
 
 #include <sstream>
 
@@ -31,7 +32,7 @@ void BindGeometry(py::module& m) {
       .def("inverse", &Eigen::Quaterniond::inverse)
       .def("__repr__", [](const Eigen::Quaterniond& self) {
         std::stringstream ss;
-        ss << "Rotation3d(quat_xyzw=[" << self.coeffs().transpose() << "])";
+        ss << "Rotation3d(quat_xyzw=[" << self.coeffs().format(vec_fmt) << "])";
         return ss.str();
       });
   py::implicitly_convertible<py::array, Eigen::Quaterniond>();
@@ -49,8 +50,8 @@ void BindGeometry(py::module& m) {
       .def("__repr__", [](const Rigid3d& self) {
         std::stringstream ss;
         ss << "Rigid3d("
-           << "quat_xyzw=[" << self.rotation.coeffs().transpose() << "], "
-           << "t=[" << self.translation.transpose() << "])";
+           << "quat_xyzw=[" << self.rotation.coeffs().format(vec_fmt) << "], "
+           << "t=[" << self.translation.format(vec_fmt) << "])";
         return ss.str();
       });
 
@@ -71,8 +72,8 @@ void BindGeometry(py::module& m) {
         std::stringstream ss;
         ss << "Sim3d("
            << "scale=" << self.scale << ", "
-           << "quat_xyzw=[" << self.rotation.coeffs().transpose() << "], "
-           << "t=[" << self.translation.transpose() << "])";
+           << "quat_xyzw=[" << self.rotation.coeffs().format(vec_fmt) << "], "
+           << "t=[" << self.translation.format(vec_fmt) << "])";
         return ss.str();
       });
 }

--- a/pycolmap/geometry/bindings.h
+++ b/pycolmap/geometry/bindings.h
@@ -40,6 +40,9 @@ void BindGeometry(py::module& m) {
   py::class_<Rigid3d>(m, "Rigid3d")
       .def(py::init<>())
       .def(py::init<const Eigen::Quaterniond&, const Eigen::Vector3d&>())
+      .def(py::init([](const Eigen::Matrix3x4d& matrix) {
+        return Rigid3d(Eigen::Quaterniond(matrix.leftCols<3>()), matrix.col(3));
+      }))
       .def_readwrite("rotation", &Rigid3d::rotation)
       .def_readwrite("translation", &Rigid3d::translation)
       .def_property_readonly("matrix", &Rigid3d::ToMatrix)
@@ -54,12 +57,13 @@ void BindGeometry(py::module& m) {
            << "t=[" << self.translation.format(vec_fmt) << "])";
         return ss.str();
       });
+  py::implicitly_convertible<py::array, Rigid3d>();
 
   py::class_<Sim3d>(m, "Sim3d")
       .def(py::init<>())
       .def(
           py::init<double, const Eigen::Quaterniond&, const Eigen::Vector3d&>())
-      .def_static("from_matrix", &Sim3d::FromMatrix)
+      .def(py::init(&Sim3d::FromMatrix))
       .def_readwrite("scale", &Sim3d::scale)
       .def_readwrite("rotation", &Sim3d::rotation)
       .def_readwrite("translation", &Sim3d::translation)
@@ -76,4 +80,5 @@ void BindGeometry(py::module& m) {
            << "t=[" << self.translation.format(vec_fmt) << "])";
         return ss.str();
       });
+  py::implicitly_convertible<py::array, Sim3d>();
 }

--- a/pycolmap/helpers.h
+++ b/pycolmap/helpers.h
@@ -12,6 +12,7 @@
 #include <regex>
 #include <string>
 
+#include <Eigen/Core>
 #include <glog/logging.h>
 #include <pybind11/embed.h>
 #include <pybind11/eval.h>
@@ -23,6 +24,11 @@
 using namespace colmap;
 using namespace pybind11::literals;
 namespace py = pybind11;
+
+const Eigen::IOFormat vec_fmt(Eigen::StreamPrecision,
+                              Eigen::DontAlignCols,
+                              ", ",
+                              ", ");
 
 template <typename T>
 inline T pyStringToEnum(const py::enum_<T>& enm, const std::string& value) {

--- a/pycolmap/helpers.h
+++ b/pycolmap/helpers.h
@@ -209,7 +209,10 @@ template <typename T, typename... options>
 inline void MakeDataclass(py::class_<T, options...> cls) {
   AddDefaultsToDocstrings(cls);
   cls.def("mergedict", &UpdateFromDict);
-  cls.def("summary", &CreateSummary<T>, "write_type"_a = false);
+  if (!py::hasattr(cls, "summary")) {
+    cls.def("summary", &CreateSummary<T>, "write_type"_a = false);
+  }
+  cls.attr("__repr__") = cls.attr("summary");
   cls.def("todict", &ConvertToDict<T>);
   cls.def(py::init([cls](py::dict dict) {
     auto self = py::object(cls());

--- a/pycolmap/helpers.h
+++ b/pycolmap/helpers.h
@@ -145,45 +145,52 @@ inline py::dict ConvertToDict(const T& self) {
   return dict;
 }
 
+bool AttributeIsFunction(const std::string& name, const py::object& attribute) {
+  return (name.find("__") == 0 || name.rfind("__") != std::string::npos ||
+          py::hasattr(attribute, "__func__") ||
+          py::hasattr(attribute, "__call__"));
+}
+
 template <typename T, typename... options>
 inline std::string CreateSummary(const T& self, bool write_type) {
   std::stringstream ss;
   auto pyself = py::cast(self);
-  std::string prefix = "    ";
+  const std::string prefix = "    ";
   bool after_subsummary = false;
   ss << pyself.attr("__class__").attr("__name__").template cast<std::string>()
-     << ":\n";
+     << ":";
   for (auto& handle : pyself.attr("__dir__")()) {
     std::string attribute = py::str(handle);
-    auto member = pyself.attr(attribute.c_str());
-
-    if (attribute.find("__") != 0 &&
-        attribute.rfind("__") == std::string::npos &&
-        !py::hasattr(member, "__func__")) {
-      if (py::hasattr(member, "summary")) {
-        std::string summ = member.attr("summary")
-                               .attr("__call__")(write_type)
-                               .template cast<std::string>();
-        summ = std::regex_replace(summ, std::regex("\n"), "\n" + prefix);
-        if (!after_subsummary) {
-          ss << prefix;
-        }
-        ss << attribute << ": " << summ;
+    py::object member;
+    try {
+      member = pyself.attr(attribute.c_str());
+    } catch (const std::exception& e) {
+      // Some properties are not valid for some uninitialized objects.
+      continue;
+    }
+    if (AttributeIsFunction(attribute, member)) {
+      continue;
+    }
+    ss << "\n";
+    if (!after_subsummary) {
+      ss << prefix;
+    }
+    ss << attribute;
+    if (py::hasattr(member, "summary")) {
+      std::string summ = member.attr("summary")
+                             .attr("__call__")(write_type)
+                             .template cast<std::string>();
+      summ = std::regex_replace(summ, std::regex("\n"), "\n" + prefix);
+      ss << ": " << summ;
+    } else {
+      if (write_type) {
+        const std::string type_str =
+            py::str(py::type::of(member).attr("__name__"));
+        ss << ": " << type_str;
         after_subsummary = true;
-      } else {
-        if (!after_subsummary) {
-          ss << prefix;
-        }
-        ss << attribute;
-        if (write_type) {
-          ss << ": "
-             << py::type::of(member)
-                    .attr("__name__")
-                    .template cast<std::string>();
-        }
-        ss << " = " << py::str(member).template cast<std::string>() << "\n";
-        after_subsummary = false;
       }
+      ss << " = " << py::str(member).template cast<std::string>();
+      after_subsummary = false;
     }
   }
   return ss.str();
@@ -194,13 +201,17 @@ void AddDefaultsToDocstrings(py::class_<T, options...> cls) {
   auto obj = cls();
   for (auto& handle : obj.attr("__dir__")()) {
     const std::string attribute = py::str(handle);
-    const auto member = obj.attr(attribute.c_str());
-    if (attribute.find("__") == 0 ||
-        attribute.rfind("__") != std::string::npos ||
-        py::hasattr(member, "__func__")) {
+    py::object member;
+    try {
+      member = obj.attr(attribute.c_str());
+    } catch (const std::exception& e) {
+      // Some properties are not valid for some uninitialized objects.
       continue;
     }
     auto prop = cls.attr(attribute.c_str());
+    if (AttributeIsFunction(attribute, member)) {
+      continue;
+    }
     const auto type_name = py::type::of(member).attr("__name__");
     const std::string doc =
         StringPrintf("%s (%s, default: %s)",
@@ -218,7 +229,6 @@ inline void MakeDataclass(py::class_<T, options...> cls) {
   if (!py::hasattr(cls, "summary")) {
     cls.def("summary", &CreateSummary<T>, "write_type"_a = false);
   }
-  cls.attr("__repr__") = cls.attr("summary");
   cls.def("todict", &ConvertToDict<T>);
   cls.def(py::init([cls](py::dict dict) {
     auto self = py::object(cls());

--- a/pycolmap/helpers.h
+++ b/pycolmap/helpers.h
@@ -189,7 +189,13 @@ inline std::string CreateSummary(const T& self, bool write_type) {
         ss << ": " << type_str;
         after_subsummary = true;
       }
-      ss << " = " << py::str(member).template cast<std::string>();
+      std::string value = py::str(member);
+      if (value.length() > 80 && py::hasattr(member, "__len__")) {
+        const int length = member.attr("__len__")().template cast<int>();
+        value = StringPrintf(
+            "%c ... %d elements ... %c", value.front(), length, value.back());
+      }
+      ss << " = " << value;
       after_subsummary = false;
     }
   }

--- a/pycolmap/scene/camera.h
+++ b/pycolmap/scene/camera.h
@@ -105,10 +105,11 @@ void BindCamera(py::module& m) {
       .def("calibration_matrix",
            &Camera::CalibrationMatrix,
            "Compute calibration matrix from params.")
-      .def("params_info",
-           &Camera::ParamsInfo,
-           "Get human-readable information about the parameter vector "
-           "ordering.")
+      .def_property_readonly(
+          "params_info",
+          &Camera::ParamsInfo,
+          "Get human-readable information about the parameter vector "
+          "ordering.")
       .def_property(
           "params",
           [](Camera& self) {

--- a/pycolmap/scene/camera.h
+++ b/pycolmap/scene/camera.h
@@ -46,7 +46,7 @@ void BindCamera(py::module& m) {
   AddStringToEnumConstructor(PyCameraModelId);
   py::implicitly_convertible<int, CameraModelId>();
 
-  py::bind_map<CameraMap>(m, "MapCameraIdCamera")
+  py::bind_map<CameraMap>(m, "MapCamerasById")
       .def("__repr__", [](const CameraMap& self) {
         std::stringstream ss;
         ss << "{";

--- a/pycolmap/scene/camera.h
+++ b/pycolmap/scene/camera.h
@@ -46,7 +46,7 @@ void BindCamera(py::module& m) {
   AddStringToEnumConstructor(PyCameraModelId);
   py::implicitly_convertible<int, CameraModelId>();
 
-  py::bind_map<CameraMap>(m, "MapCamerasById")
+  py::bind_map<CameraMap>(m, "MapCameraIdCamera")
       .def("__repr__", [](const CameraMap& self) {
         std::stringstream ss;
         ss << "{";

--- a/pycolmap/scene/camera.h
+++ b/pycolmap/scene/camera.h
@@ -77,8 +77,8 @@ void BindCamera(py::module& m) {
       .def_property(
           "model_name",
           &Camera::ModelName,
-          [](Camera& self, std::string model_name) {
-            self.model_id = CameraModelNameToId(model_name);
+          [](Camera& self, CameraModelId model_id) {  // implicit conversion
+            self.model_id = model_id;
           },
           "Camera model name (connected to model_id).")
       .def_readwrite("width", &Camera::width, "Width of camera sensor.")
@@ -203,8 +203,8 @@ void BindCamera(py::module& m) {
       .def("__repr__", &PrintCamera);
   PyCamera.def(py::init([PyCamera](py::dict dict) {
                  auto self = py::object(PyCamera());
-                 for (auto& it : dict) {
-                   auto key_str = it.first.cast<std::string>();
+                 for (const auto& it : dict) {
+                   const auto key_str = it.first.cast<std::string>();
                    if ((key_str == "model") || (key_str == "model_name")) {
                      self.attr("model_id") = it.second;  // Implicit conversion.
                    } else {
@@ -218,6 +218,5 @@ void BindCamera(py::module& m) {
     py::dict dict = kwargs.cast<py::dict>();
     return PyCamera(dict).cast<Camera>();
   }));
-
   py::implicitly_convertible<py::dict, Camera>();
 }

--- a/pycolmap/scene/camera.h
+++ b/pycolmap/scene/camera.h
@@ -46,7 +46,7 @@ void BindCamera(py::module& m) {
   AddStringToEnumConstructor(PyCameraModelId);
   py::implicitly_convertible<int, CameraModelId>();
 
-  py::bind_map<CameraMap>(m, "MapCameraIdCamera")
+  py::bind_map<CameraMap>(m, "MapCameraIdToCamera")
       .def("__repr__", [](const CameraMap& self) {
         std::stringstream ss;
         ss << "{";

--- a/pycolmap/scene/camera.h
+++ b/pycolmap/scene/camera.h
@@ -46,7 +46,21 @@ void BindCamera(py::module& m) {
   AddStringToEnumConstructor(PyCameraModelId);
   py::implicitly_convertible<int, CameraModelId>();
 
-  py::bind_map<CameraMap>(m, "MapCameraIdCamera");
+  py::bind_map<CameraMap>(m, "MapCameraIdCamera")
+      .def("__repr__", [](const CameraMap& self) {
+        std::stringstream ss;
+        ss << "{";
+        bool is_first = true;
+        for (const auto& pair : self) {
+          if (!is_first) {
+            ss << ",\n ";
+          }
+          is_first = false;
+          ss << pair.first << ": " << PrintCamera(pair.second);
+        }
+        ss << "}";
+        return ss.str();
+      });
 
   py::class_<Camera, std::shared_ptr<Camera>> PyCamera(m, "Camera");
   PyCamera.def(py::init<>())

--- a/pycolmap/scene/correspondence_graph.h
+++ b/pycolmap/scene/correspondence_graph.h
@@ -33,8 +33,8 @@ void BindCorrespondenceGraph(py::module& m) {
              return CorrespondenceGraph::Correspondence(self);
            })
       .def("__repr__", [](const CorrespondenceGraph::Correspondence& self) {
-        return "<Correspondence 'image_id=" + std::to_string(self.image_id) +
-               ",point2D_idx=" + std::to_string(self.point2D_idx) + "'>";
+        return "Correspondence(image_id=" + std::to_string(self.image_id) +
+               ", point2D_idx=" + std::to_string(self.point2D_idx) + ")";
       });
 
   py::class_<CorrespondenceGraph, std::shared_ptr<CorrespondenceGraph>>(
@@ -100,8 +100,8 @@ void BindCorrespondenceGraph(py::module& m) {
            })
       .def("__repr__", [](const CorrespondenceGraph& self) {
         std::stringstream ss;
-        ss << "<CorrespondenceGraph 'num_images=" << self.NumImages()
-           << ", num_image_pairs=" << self.NumImagePairs() << "'>";
+        ss << "CorrespondenceGraph(num_images=" << self.NumImages()
+           << ", num_image_pairs=" << self.NumImagePairs() << ")";
         return ss.str();
       });
 }

--- a/pycolmap/scene/image.h
+++ b/pycolmap/scene/image.h
@@ -50,7 +50,7 @@ std::shared_ptr<Image> MakeImage(const std::string& name,
 }
 
 void BindImage(py::module& m) {
-  py::bind_map<ImageMap>(m, "MapImageIdImage")
+  py::bind_map<ImageMap>(m, "MapImagesById")
       .def("__repr__", [](const ImageMap& self) {
         std::stringstream ss;
         ss << "{";

--- a/pycolmap/scene/image.h
+++ b/pycolmap/scene/image.h
@@ -52,17 +52,18 @@ std::shared_ptr<Image> MakeImage(const std::string& name,
 void BindImage(py::module& m) {
   py::bind_map<ImageMap>(m, "MapImageIdImage")
       .def("__repr__", [](const ImageMap& self) {
-        std::string repr = "{";
+        std::stringstream ss;
+        ss << "{";
         bool is_first = true;
-        for (auto& pair : self) {
+        for (const auto& pair : self) {
           if (!is_first) {
-            repr += ", ";
+            ss << ",\n ";
           }
           is_first = false;
-          repr += std::to_string(pair.first) + ": " + PrintImage(pair.second);
+          ss << pair.first << ": " << PrintImage(pair.second);
         }
-        repr += "}";
-        return repr;
+        ss << "}";
+        return ss.str();
       });
 
   py::class_<Image, std::shared_ptr<Image>>(m, "Image")

--- a/pycolmap/scene/image.h
+++ b/pycolmap/scene/image.h
@@ -50,7 +50,7 @@ std::shared_ptr<Image> MakeImage(const std::string& name,
 }
 
 void BindImage(py::module& m) {
-  py::bind_map<ImageMap>(m, "MapImageIdImage")
+  py::bind_map<ImageMap>(m, "MapImageIdToImage")
       .def("__repr__", [](const ImageMap& self) {
         std::stringstream ss;
         ss << "{";

--- a/pycolmap/scene/image.h
+++ b/pycolmap/scene/image.h
@@ -50,7 +50,7 @@ std::shared_ptr<Image> MakeImage(const std::string& name,
 }
 
 void BindImage(py::module& m) {
-  py::bind_map<ImageMap>(m, "MapImagesById")
+  py::bind_map<ImageMap>(m, "MapImageIdImage")
       .def("__repr__", [](const ImageMap& self) {
         std::stringstream ss;
         ss << "{";

--- a/pycolmap/scene/image.h
+++ b/pycolmap/scene/image.h
@@ -181,13 +181,14 @@ void BindImage(py::module& m) {
                     &Image::IsRegistered,
                     &Image::SetRegistered,
                     "Whether image is registered in the reconstruction.")
-      .def("num_points2D",
-           &Image::NumPoints2D,
-           "Get the number of image points (keypoints).")
-      .def("num_points3D",
-           &Image::NumPoints3D,
-           "Get the number of triangulations, i.e. the number of points that\n"
-           "are part of a 3D point track.")
+      .def_property_readonly("num_points2D",
+                             &Image::NumPoints2D,
+                             "Get the number of image points (keypoints).")
+      .def_property_readonly(
+          "num_points3D",
+          &Image::NumPoints3D,
+          "Get the number of triangulations, i.e. the number of points that\n"
+          "are part of a 3D point track.")
       .def_property(
           "num_observations",
           &Image::NumObservations,

--- a/pycolmap/scene/image.h
+++ b/pycolmap/scene/image.h
@@ -21,14 +21,14 @@ PYBIND11_MAKE_OPAQUE(ImageMap);
 
 std::string PrintImage(const Image& image) {
   std::stringstream ss;
-  ss << "<Image 'image_id="
+  ss << "Image(image_id="
      << (image.ImageId() != kInvalidImageId ? std::to_string(image.ImageId())
                                             : "Invalid")
      << ", camera_id="
      << (image.HasCamera() ? std::to_string(image.CameraId()) : "Invalid")
      << ", name=\"" << image.Name() << "\""
      << ", triangulated=" << image.NumPoints3D() << "/" << image.NumPoints2D()
-     << "'>";
+     << ")";
   return ss.str();
 }
 
@@ -286,19 +286,5 @@ void BindImage(py::module& m) {
       .def("__copy__", [](const Image& self) { return Image(self); })
       .def("__deepcopy__",
            [](const Image& self, py::dict) { return Image(self); })
-      .def("__repr__", [](const Image& self) { return PrintImage(self); })
-      .def("summary", [](const Image& self) {
-        std::stringstream ss;
-        ss << "Image:\n\timage_id = "
-           << (self.ImageId() != kInvalidImageId
-                   ? std::to_string(self.ImageId())
-                   : "Invalid")
-           << "\n\tcamera_id = "
-           << (self.HasCamera() ? std::to_string(self.CameraId()) : "Invalid")
-           << "\n\tname = " << self.Name()
-           << "\n\ttriangulated = " << self.NumPoints3D() << "/"
-           << self.NumPoints2D() << "\n\tcam_from_world = ["
-           << self.CamFromWorld().ToMatrix() << "]";
-        return ss.str();
-      });
+      .def("__repr__", &PrintImage);
 }

--- a/pycolmap/scene/image.h
+++ b/pycolmap/scene/image.h
@@ -5,7 +5,10 @@
 #include "colmap/util/misc.h"
 #include "colmap/util/types.h"
 
+#include "pycolmap/helpers.h"
 #include "pycolmap/log_exceptions.h"
+
+#include <sstream>
 
 #include <pybind11/eigen.h>
 #include <pybind11/pybind11.h>
@@ -66,8 +69,8 @@ void BindImage(py::module& m) {
         return ss.str();
       });
 
-  py::class_<Image, std::shared_ptr<Image>>(m, "Image")
-      .def(py::init<>())
+  py::class_<Image, std::shared_ptr<Image>> PyImage(m, "Image");
+  PyImage.def(py::init<>())
       .def(py::init(&MakeImage<Point2D>),
            "name"_a = "",
            "points2D"_a = std::vector<Point2D>(),
@@ -288,4 +291,5 @@ void BindImage(py::module& m) {
       .def("__deepcopy__",
            [](const Image& self, py::dict) { return Image(self); })
       .def("__repr__", &PrintImage);
+  MakeDataclass(PyImage);
 }

--- a/pycolmap/scene/point2D.h
+++ b/pycolmap/scene/point2D.h
@@ -17,9 +17,9 @@ using namespace colmap;
 using namespace pybind11::literals;
 namespace py = pybind11;
 
-using vector_Point2D =
+using Point2DVector =
     std::vector<struct Point2D, Eigen::aligned_allocator<Point2D>>;
-PYBIND11_MAKE_OPAQUE(vector_Point2D);
+PYBIND11_MAKE_OPAQUE(Point2DVector);
 
 std::string PrintPoint2D(const Point2D& p2D) {
   std::stringstream ss;
@@ -29,8 +29,8 @@ std::string PrintPoint2D(const Point2D& p2D) {
 }
 
 void BindPoint2D(py::module& m) {
-  py::bind_vector<vector_Point2D>(m, "ListPoint2D")
-      .def("__repr__", [](const vector_Point2D& self) {
+  py::bind_vector<Point2DVector>(m, "ListPoint2D")
+      .def("__repr__", [](const Point2DVector& self) {
         std::string repr = "[";
         bool is_first = true;
         for (auto& p2D : self) {

--- a/pycolmap/scene/point2D.h
+++ b/pycolmap/scene/point2D.h
@@ -5,6 +5,7 @@
 #include "colmap/util/misc.h"
 #include "colmap/util/types.h"
 
+#include "pycolmap/helpers.h"
 #include "pycolmap/log_exceptions.h"
 
 #include <Eigen/StdVector>
@@ -23,8 +24,8 @@ PYBIND11_MAKE_OPAQUE(Point2DVector);
 
 std::string PrintPoint2D(const Point2D& p2D) {
   std::stringstream ss;
-  ss << "<Point2D 'xy=[" << p2D.xy.transpose() << "], point3D_id="
-     << (p2D.HasPoint3D() ? std::to_string(p2D.point3D_id) : "Invalid") << "'>";
+  ss << "Point2D(xy=[" << p2D.xy.format(vec_fmt) << "], point3D_id="
+     << (p2D.HasPoint3D() ? std::to_string(p2D.point3D_id) : "Invalid") << ")";
   return ss.str();
 }
 

--- a/pycolmap/scene/point2D.h
+++ b/pycolmap/scene/point2D.h
@@ -45,8 +45,8 @@ void BindPoint2D(py::module& m) {
         return repr;
       });
 
-  py::class_<Point2D, std::shared_ptr<Point2D>>(m, "Point2D")
-      .def(py::init<>())
+  py::class_<Point2D, std::shared_ptr<Point2D>> PyPoint2D(m, "Point2D");
+  PyPoint2D.def(py::init<>())
       .def(py::init<const Eigen::Vector2d&, size_t>(),
            "xy"_a,
            "point3D_id"_a = kInvalidPoint3DId)
@@ -57,4 +57,5 @@ void BindPoint2D(py::module& m) {
       .def("__deepcopy__",
            [](const Point2D& self, py::dict) { return Point2D(self); })
       .def("__repr__", &PrintPoint2D);
+  MakeDataclass(PyPoint2D);
 }

--- a/pycolmap/scene/point3D.h
+++ b/pycolmap/scene/point3D.h
@@ -18,10 +18,10 @@ using Point3DMap = std::unordered_map<point3D_t, Point3D>;
 PYBIND11_MAKE_OPAQUE(Point3DMap);
 
 void BindPoint3D(py::module& m) {
-  py::bind_map_fix<Point3DMap>(m, "MapPoints3DById")
+  py::bind_map_fix<Point3DMap>(m, "MapPoint3DIdPoint3D")
       .def("__repr__", [](const Point3DMap& self) {
-        return "MapPoints3DById(num_points3D=" + std::to_string(self.size()) +
-               ")";
+        return "MapPoint3DIdPoint3D(num_points3D=" +
+               std::to_string(self.size()) + ")";
       });
 
   auto PyPoint3D =

--- a/pycolmap/scene/point3D.h
+++ b/pycolmap/scene/point3D.h
@@ -18,10 +18,10 @@ using Point3DMap = std::unordered_map<point3D_t, Point3D>;
 PYBIND11_MAKE_OPAQUE(Point3DMap);
 
 void BindPoint3D(py::module& m) {
-  py::bind_map_fix<Point3DMap>(m, "MapPoint3DIdPoint3D")
+  py::bind_map_fix<Point3DMap>(m, "MapPoints3DById")
       .def("__repr__", [](const Point3DMap& self) {
-        return "MapPoint3DIdPoint3D(num_points3D=" +
-               std::to_string(self.size()) + ")";
+        return "MapPoints3DById(num_points3D=" + std::to_string(self.size()) +
+               ")";
       });
 
   auto PyPoint3D =

--- a/pycolmap/scene/point3D.h
+++ b/pycolmap/scene/point3D.h
@@ -24,15 +24,21 @@ void BindPoint3D(py::module& m) {
                std::to_string(self.size()) + ")";
       });
 
-  auto PyPoint3D =
-      py::class_<Point3D, std::shared_ptr<Point3D>>(m, "Point3D")
-          .def(py::init<>())
-          .def_readwrite("xyz", &Point3D::xyz)
-          .def_readwrite("color", &Point3D::color)
-          .def_readwrite("error", &Point3D::error)
-          .def_readwrite("track", &Point3D::track)
-          .def("__copy__", [](const Point3D& self) { return Point3D(self); })
-          .def("__deepcopy__",
-               [](const Point3D& self, py::dict) { return Point3D(self); });
+  py::class_<Point3D, std::shared_ptr<Point3D>> PyPoint3D(m, "Point3D");
+  PyPoint3D.def(py::init<>())
+      .def_readwrite("xyz", &Point3D::xyz)
+      .def_readwrite("color", &Point3D::color)
+      .def_readwrite("error", &Point3D::error)
+      .def_readwrite("track", &Point3D::track)
+      .def("__copy__", [](const Point3D& self) { return Point3D(self); })
+      .def("__deepcopy__",
+           [](const Point3D& self, py::dict) { return Point3D(self); })
+      .def("__repr__", [](const Point3D& self) {
+        std::stringstream ss;
+        ss << "Point3D(xyz=[" << self.xyz.format(vec_fmt) << "], color=["
+           << self.color.format(vec_fmt) << "], error=" << self.error
+           << ", track=Track(length=" << self.track.Length() << "))";
+        return ss.str();
+      });
   MakeDataclass(PyPoint3D);
 }

--- a/pycolmap/scene/point3D.h
+++ b/pycolmap/scene/point3D.h
@@ -18,9 +18,9 @@ using Point3DMap = std::unordered_map<point3D_t, Point3D>;
 PYBIND11_MAKE_OPAQUE(Point3DMap);
 
 void BindPoint3D(py::module& m) {
-  py::bind_map_fix<Point3DMap>(m, "MapPoint3DIdPoint3D")
+  py::bind_map_fix<Point3DMap>(m, "MapPoint3DIdToPoint3D")
       .def("__repr__", [](const Point3DMap& self) {
-        return "MapPoint3DIdPoint3D(num_points3D=" +
+        return "MapPoint3DIdToPoint3D(num_points3D=" +
                std::to_string(self.size()) + ")";
       });
 

--- a/pycolmap/scene/point3D.h
+++ b/pycolmap/scene/point3D.h
@@ -18,7 +18,11 @@ using Point3DMap = std::unordered_map<point3D_t, Point3D>;
 PYBIND11_MAKE_OPAQUE(Point3DMap);
 
 void BindPoint3D(py::module& m) {
-  py::bind_map_fix<Point3DMap>(m, "MapPoint3DIdPoint3D");
+  py::bind_map_fix<Point3DMap>(m, "MapPoint3DIdPoint3D")
+      .def("__repr__", [](const Point3DMap& self) {
+        return "MapPoint3DIdPoint3D(num_points3D=" +
+               std::to_string(self.size()) + ")";
+      });
 
   auto PyPoint3D =
       py::class_<Point3D, std::shared_ptr<Point3D>>(m, "Point3D")

--- a/pycolmap/scene/reconstruction.h
+++ b/pycolmap/scene/reconstruction.h
@@ -61,8 +61,7 @@ void BindReconstruction(py::module& m) {
       .def(py::init([](const py::object input_path) {
              std::string path = py::str(input_path).cast<std::string>();
              THROW_CHECK_RECONSTRUCTION_EXISTS(path);
-             auto reconstruction =
-                 std::unique_ptr<Reconstruction>(new Reconstruction());
+             auto reconstruction = std::make_shared<Reconstruction>();
              reconstruction->Read(path);
              return reconstruction;
            }),

--- a/pycolmap/scene/reconstruction.h
+++ b/pycolmap/scene/reconstruction.h
@@ -427,11 +427,11 @@ void BindReconstruction(py::module& m) {
       .def("__repr__",
            [](const Reconstruction& self) {
              std::stringstream ss;
-             ss << "<Reconstruction 'num_reg_images=" << self.NumRegImages()
+             ss << "Reconstruction(num_reg_images=" << self.NumRegImages()
                 << ", num_cameras=" << self.NumCameras()
                 << ", num_points3D=" << self.NumPoints3D()
                 << ", num_observations=" << self.ComputeNumObservations()
-                << "'>";
+                << ")";
              return ss.str();
            })
       .def("summary", [](const Reconstruction& self) {

--- a/pycolmap/scene/track.h
+++ b/pycolmap/scene/track.h
@@ -27,8 +27,8 @@ void BindTrack(py::module& m) {
           "__deepcopy__",
           [](const TrackElement& self, py::dict) { return TrackElement(self); })
       .def("__repr__", [](const TrackElement& self) {
-        return "<TrackElement 'image_id=" + std::to_string(self.image_id) +
-               ",point2D_idx=" + std::to_string(self.point2D_idx) + "'>";
+        return "TrackElement(image_id=" + std::to_string(self.image_id) +
+               ", point2D_idx=" + std::to_string(self.point2D_idx) + ")";
       });
 
   py::class_<Track, std::shared_ptr<Track>>(m, "Track")
@@ -68,6 +68,6 @@ void BindTrack(py::module& m) {
       .def("__deepcopy__",
            [](const Track& self, py::dict) { return Track(self); })
       .def("__repr__", [](const Track& self) {
-        return "<Track 'length=" + std::to_string(self.Length()) + "'>";
+        return "Track(length=" + std::to_string(self.Length()) + ")";
       });
 }

--- a/pycolmap/scene/track.h
+++ b/pycolmap/scene/track.h
@@ -6,6 +6,8 @@
 
 #include "pycolmap/log_exceptions.h"
 
+#include <memory>
+
 #include <pybind11/eigen.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
@@ -34,7 +36,7 @@ void BindTrack(py::module& m) {
   py::class_<Track, std::shared_ptr<Track>>(m, "Track")
       .def(py::init<>())
       .def(py::init([](const std::vector<TrackElement>& elements) {
-        std::unique_ptr<Track> track = std::unique_ptr<Track>(new Track());
+        auto track = std::make_shared<Track>();
         track->AddElements(elements);
         return track;
       }))

--- a/pycolmap/sfm/incremental_triangulator.h
+++ b/pycolmap/sfm/incremental_triangulator.h
@@ -98,7 +98,7 @@ void BindIncrementalTriangulator(py::module& m) {
            })
       .def("__repr__", [](const IncrementalTriangulator& self) {
         std::stringstream ss;
-        ss << "<IncrementalTriangulator>";
+        ss << "IncrementalTriangulator()";
         return ss.str();
       });
 }

--- a/pycolmap/sfm/incremental_triangulator.h
+++ b/pycolmap/sfm/incremental_triangulator.h
@@ -71,6 +71,9 @@ void BindIncrementalTriangulator(py::module& m) {
                      "degenerate intrinsics.");
   MakeDataclass(PyOpts);
 
+  // TODO: Add bindings for GetModifiedPoints3D.
+  // TODO: Add bindings for Find, Create, Continue, Merge, Complete,
+  // HasCameraBogusParams once they become public.
   py::class_<IncrementalTriangulator, std::shared_ptr<IncrementalTriangulator>>(
       m, "IncrementalTriangulator")
       .def(py::init<std::shared_ptr<CorrespondenceGraph>,
@@ -85,9 +88,6 @@ void BindIncrementalTriangulator(py::module& m) {
            &IncrementalTriangulator::ClearModifiedPoints3D)
       .def("merge_tracks", &IncrementalTriangulator::MergeTracks)
       .def("complete_tracks", &IncrementalTriangulator::CompleteTracks)
-      // Missing bindings: GetModifiedPoints3D
-      // Private bindings: Find, Create, Continue, Merge, Complete,
-      // HasCameraBogusParams
       .def("__copy__",
            [](const IncrementalTriangulator& self) {
              return IncrementalTriangulator(self);
@@ -97,8 +97,7 @@ void BindIncrementalTriangulator(py::module& m) {
              return IncrementalTriangulator(self);
            })
       .def("__repr__", [](const IncrementalTriangulator& self) {
-        std::stringstream ss;
-        ss << "IncrementalTriangulator()";
-        return ss.str();
+        // TODO: Print reconstruction and correspondence_graph once public.
+        return "IncrementalTriangulator()";
       });
 }


### PR DESCRIPTION
Breaking changes:
- `Sim3d.from_matrix` becomes a constructor `Sim3d(matrix)`
- `Camera.{model_id,model_name}` are merged into `Camera.model` (via enum)
- `Camera.params_info` and `Image.{num_points2D,num_points3D}` become read-only properties (previously: functions)

Samples:
```
>> camera
Camera(camera_id=1, model=SIMPLE_RADIAL, width=780, height=1063, params=[1245.950053, 390.000000, 531.500000, 0.020831] (f, cx, cy, k))

>> print(rec.cameras[1].summary())
Camera:
    camera_id = 1
    model = CameraModelId.SIMPLE_RADIAL
    width = 780
    height = 1063
    focal_length = 1245.950052502772
    focal_length_x = 1245.950052502772
    focal_length_y = 1245.950052502772
    has_prior_focal_length = False
    principal_point_x = 390.0
    principal_point_y = 531.5
    params_info = f, cx, cy, k
    params = [1.24595005e+03 3.90000000e+02 5.31500000e+02 2.08308406e-02]

>> image
Image(image_id=1, camera_id=1, name="mapping/02928139_3448003521.jpg", triangulated=760/2313)

>> print(image.summary())
Image:
    image_id = 1
    camera_id = 1
    name = mapping/02928139_3448003521.jpg
    cam_from_world = Rigid3d(quat_xyzw=[0.0500042, 0.243753, -0.155877, 0.955922], t=[-1.37836, 0.000488448, -1.59398])
    cam_from_world_prior = Rigid3d(quat_xyzw=[nan, nan, nan, nan], t=[nan, nan, nan])
    points2D = [ ... 2313 elements ... ]
    registered = True
    num_points2D = 2313
    num_points3D = 760
    num_observations = 0
    num_correspondences = 0

>> sim3d
Sim3d(scale=1, quat_xyzw=[0, 0, 0, 1], t=[0, 0, 0])
```