### PR TITLE
Make glog usable in Python

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.egg-info/
 build/
 .cache/
+example/

--- a/example.py
+++ b/example.py
@@ -1,0 +1,43 @@
+import shutil
+import urllib.request
+import zipfile
+from pathlib import Path
+
+import pycolmap
+from pycolmap import logging
+
+
+def run():
+    output_path = Path("example/")
+    image_path = output_path / "Fountain/images"
+    database_path = output_path / "database.db"
+    sfm_path = output_path / "sfm"
+
+    output_path.mkdir(exist_ok=True)
+    logging.set_log_destination(logging.INFO, output_path / "INFO.log.")  # + time
+
+    data_url = "https://cvg-data.inf.ethz.ch/local-feature-evaluation-schoenberger2017/Strecha-Fountain.zip"
+    if not image_path.exists():
+        logging.info("Downloading the data.")
+        zip_path = output_path / "data.zip"
+        urllib.request.urlretrieve(data_url, zip_path)
+        with zipfile.ZipFile(zip_path, "r") as fid:
+            fid.extractall(output_path)
+        logging.info(f"Data extracted to {output_path}.")
+
+    if database_path.exists():
+        database_path.unlink()
+    pycolmap.extract_features(database_path, image_path)
+
+    pycolmap.match_exhaustive(database_path)
+
+    if sfm_path.exists():
+        shutil.rmtree(sfm_path)
+    sfm_path.mkdir(exist_ok=True)
+    recs = pycolmap.incremental_mapping(database_path, image_path, sfm_path)
+    for idx, rec in recs.items():
+        logging.info(f"#{idx} {rec.summary()}")
+
+
+if __name__ == "__main__":
+    run()

--- a/pycolmap/main.cc
+++ b/pycolmap/main.cc
@@ -28,17 +28,7 @@ struct Logging {
   };
 };  // dummy class
 
-PYBIND11_MODULE(pycolmap, m) {
-  m.doc() = "COLMAP plugin";
-#ifdef VERSION_INFO
-  m.attr("__version__") = py::str(VERSION_INFO);
-#else
-  m.attr("__version__") = py::str("dev");
-#endif
-  m.attr("has_cuda") = IsGPU(Device::AUTO);
-  m.attr("COLMAP_version") = py::str(GetVersionInfo());
-  m.attr("COLMAP_build") = py::str(GetBuildInfo());
-
+void BindLogging(py::module& m) {
   auto PyLogging =
       py::class_<Logging>(m, "logging")
           .def_readwrite_static("minloglevel", &FLAGS_minloglevel)
@@ -62,6 +52,18 @@ PYBIND11_MODULE(pycolmap, m) {
   google::InitGoogleLogging("");
   google::InstallFailureSignalHandler();
   FLAGS_logtostderr = true;
+}
+
+PYBIND11_MODULE(pycolmap, m) {
+  m.doc() = "COLMAP plugin";
+#ifdef VERSION_INFO
+  m.attr("__version__") = py::str(VERSION_INFO);
+#else
+  m.attr("__version__") = py::str("dev");
+#endif
+  m.attr("has_cuda") = IsGPU(Device::AUTO);
+  m.attr("COLMAP_version") = py::str(GetVersionInfo());
+  m.attr("COLMAP_build") = py::str(GetBuildInfo());
 
   auto PyDevice = py::enum_<Device>(m, "Device")
                       .value("auto", Device::AUTO)
@@ -69,6 +71,7 @@ PYBIND11_MODULE(pycolmap, m) {
                       .value("cuda", Device::CUDA);
   AddStringToEnumConstructor(PyDevice);
 
+  BindLogging(m);
   BindGeometry(m);
   BindOptim(m);
   BindScene(m);

--- a/pycolmap/main.cc
+++ b/pycolmap/main.cc
@@ -30,20 +30,17 @@ struct Logging {
 };  // dummy class
 
 void BindLogging(py::module& m) {
-  auto PyLogging =
-      py::class_<Logging>(m, "logging")
-          .def_readwrite_static("minloglevel", &FLAGS_minloglevel)
-          .def_readwrite_static("stderrthreshold", &FLAGS_stderrthreshold)
-          .def_readwrite_static("log_dir", &FLAGS_log_dir)
-          .def_readwrite_static("logtostderr", &FLAGS_logtostderr)
-          .def_readwrite_static("alsologtostderr", &FLAGS_alsologtostderr)
-          .def_static("info", [](const std::string& msg) { LOG(INFO) << msg; })
-          .def_static("warning",
-                      [](const std::string& msg) { LOG(WARNING) << msg; })
-          .def_static("error",
-                      [](const std::string& msg) { LOG(ERROR) << msg; })
-          .def_static("fatal",
-                      [](const std::string& msg) { LOG(FATAL) << msg; });
+  py::class_<Logging> PyLogging(m, "logging");
+  PyLogging.def_readwrite_static("minloglevel", &FLAGS_minloglevel)
+      .def_readwrite_static("stderrthreshold", &FLAGS_stderrthreshold)
+      .def_readwrite_static("log_dir", &FLAGS_log_dir)
+      .def_readwrite_static("logtostderr", &FLAGS_logtostderr)
+      .def_readwrite_static("alsologtostderr", &FLAGS_alsologtostderr)
+      .def_static("info", [](const std::string& msg) { LOG(INFO) << msg; })
+      .def_static("warning",
+                  [](const std::string& msg) { LOG(WARNING) << msg; })
+      .def_static("error", [](const std::string& msg) { LOG(ERROR) << msg; })
+      .def_static("fatal", [](const std::string& msg) { LOG(FATAL) << msg; });
   py::enum_<Logging::LogSeverity>(PyLogging, "Level")
       .value("INFO", Logging::LogSeverity::GLOG_INFO)
       .value("WARNING", Logging::LogSeverity::GLOG_WARNING)

--- a/pycolmap/main.cc
+++ b/pycolmap/main.cc
@@ -36,6 +36,12 @@ void BindLogging(py::module& m) {
       .def_readwrite_static("log_dir", &FLAGS_log_dir)
       .def_readwrite_static("logtostderr", &FLAGS_logtostderr)
       .def_readwrite_static("alsologtostderr", &FLAGS_alsologtostderr)
+      .def_static(
+          "set_log_destination",
+          [](const Logging::LogSeverity severity, const std::string& path) {
+            google::SetLogDestination(
+                static_cast<google::LogSeverity>(severity), path.c_str());
+          })
       .def_static("info", [](const std::string& msg) { LOG(INFO) << msg; })
       .def_static("warning",
                   [](const std::string& msg) { LOG(WARNING) << msg; })
@@ -49,7 +55,7 @@ void BindLogging(py::module& m) {
       .export_values();
   google::InitGoogleLogging("");
   google::InstallFailureSignalHandler();
-  FLAGS_logtostderr = true;
+  FLAGS_alsologtostderr = true;
 }
 
 PYBIND11_MODULE(pycolmap, m) {

--- a/pycolmap/main.cc
+++ b/pycolmap/main.cc
@@ -20,11 +20,12 @@ namespace py = pybind11;
 using namespace colmap;
 
 struct Logging {
-  enum class Level {
-    INFO_ = google::GLOG_INFO,
-    WARNING_ = google::GLOG_WARNING,
-    ERROR_ = google::GLOG_ERROR,
-    FATAL_ = google::GLOG_FATAL,
+  // TODO: Replace with google::LogSeverity in glog >= v0.7.0
+  enum class LogSeverity {
+    GLOG_INFO = google::GLOG_INFO,
+    GLOG_WARNING = google::GLOG_WARNING,
+    GLOG_ERROR = google::GLOG_ERROR,
+    GLOG_FATAL = google::GLOG_FATAL,
   };
 };  // dummy class
 
@@ -43,11 +44,11 @@ void BindLogging(py::module& m) {
                       [](const std::string& msg) { LOG(ERROR) << msg; })
           .def_static("fatal",
                       [](const std::string& msg) { LOG(FATAL) << msg; });
-  py::enum_<Logging::Level>(PyLogging, "Level")
-      .value("INFO", Logging::Level::INFO_)
-      .value("WARNING", Logging::Level::WARNING_)
-      .value("ERROR", Logging::Level::ERROR_)
-      .value("FATAL", Logging::Level::FATAL_)
+  py::enum_<Logging::LogSeverity>(PyLogging, "Level")
+      .value("INFO", Logging::LogSeverity::GLOG_INFO)
+      .value("WARNING", Logging::LogSeverity::GLOG_WARNING)
+      .value("ERROR", Logging::LogSeverity::GLOG_ERROR)
+      .value("FATAL", Logging::LogSeverity::GLOG_FATAL)
       .export_values();
   google::InitGoogleLogging("");
   google::InstallFailureSignalHandler();


### PR DESCRIPTION
- Log the Python call stack frame when called from Python: file name, function name, line number
- Log both C++ and Python messages to the same file:
```python
from pycolmap import logging
logging.set_log_destination(logging.INFO, path / "INFO.log.")

def run():
    logging.info("Logging some information.")
    pycolmap.some_cpp_function()
    logging.info("Done!")
```
Output in `path/INFO.log.20240114-232404.3281132`:
```
I0114 23:24:04.867597 3281132 example.py:run:26] Logging some information.
I0114 23:24:08.361011 3281291 some_cpp_file.cc:198] ...
I0114 23:24:22.513118 3281132 example.py:run:28] Done!
```