### PR TITLE
Enable pickling of objects

### DIFF
--- a/pycolmap/geometry/bindings.h
+++ b/pycolmap/geometry/bindings.h
@@ -19,8 +19,8 @@ using namespace pybind11::literals;
 void BindGeometry(py::module& m) {
   BindHomographyGeometry(m);
 
-  py::class_<Eigen::Quaterniond>(m, "Rotation3d")
-      .def(py::init([]() { return Eigen::Quaterniond::Identity(); }))
+  py::class_<Eigen::Quaterniond> PyRotation3d(m, "Rotation3d");
+  PyRotation3d.def(py::init([]() { return Eigen::Quaterniond::Identity(); }))
       .def(py::init<const Eigen::Vector4d&>(), "xyzw"_a)
       .def(py::init<const Eigen::Matrix3d&>(), "rotmat"_a)
       .def(py::self * Eigen::Quaterniond())
@@ -36,9 +36,10 @@ void BindGeometry(py::module& m) {
         return ss.str();
       });
   py::implicitly_convertible<py::array, Eigen::Quaterniond>();
+  MakeDataclass(PyRotation3d);
 
-  py::class_<Rigid3d>(m, "Rigid3d")
-      .def(py::init<>())
+  py::class_<Rigid3d> PyRigid3d(m, "Rigid3d");
+  PyRigid3d.def(py::init<>())
       .def(py::init<const Eigen::Quaterniond&, const Eigen::Vector3d&>())
       .def(py::init([](const Eigen::Matrix3x4d& matrix) {
         return Rigid3d(Eigen::Quaterniond(matrix.leftCols<3>()), matrix.col(3));
@@ -58,9 +59,10 @@ void BindGeometry(py::module& m) {
         return ss.str();
       });
   py::implicitly_convertible<py::array, Rigid3d>();
+  MakeDataclass(PyRigid3d);
 
-  py::class_<Sim3d>(m, "Sim3d")
-      .def(py::init<>())
+  py::class_<Sim3d> PySim3d(m, "Sim3d");
+  PySim3d.def(py::init<>())
       .def(
           py::init<double, const Eigen::Quaterniond&, const Eigen::Vector3d&>())
       .def(py::init(&Sim3d::FromMatrix))
@@ -81,4 +83,5 @@ void BindGeometry(py::module& m) {
         return ss.str();
       });
   py::implicitly_convertible<py::array, Sim3d>();
+  MakeDataclass(PySim3d);
 }

--- a/pycolmap/geometry/bindings.h
+++ b/pycolmap/geometry/bindings.h
@@ -25,9 +25,13 @@ void BindGeometry(py::module& m) {
       .def(py::init<const Eigen::Matrix3d&>(), "rotmat"_a)
       .def(py::self * Eigen::Quaterniond())
       .def(py::self * Eigen::Vector3d())
+      .def_property("quat",
+                    py::overload_cast<>(&Eigen::Quaterniond::coeffs),
+                    [](Eigen::Quaterniond& self, const Eigen::Vector4d& quat) {
+                      self.coeffs() = quat;
+                    })
       .def("normalize", &Eigen::Quaterniond::normalize)
       .def("matrix", &Eigen::Quaterniond::toRotationMatrix)
-      .def("quat", py::overload_cast<>(&Eigen::Quaterniond::coeffs))
       .def("norm", &Eigen::Quaterniond::norm)
       .def("inverse", &Eigen::Quaterniond::inverse)
       .def("__repr__", [](const Eigen::Quaterniond& self) {
@@ -46,7 +50,7 @@ void BindGeometry(py::module& m) {
       }))
       .def_readwrite("rotation", &Rigid3d::rotation)
       .def_readwrite("translation", &Rigid3d::translation)
-      .def_property_readonly("matrix", &Rigid3d::ToMatrix)
+      .def("matrix", &Rigid3d::ToMatrix)
       .def(py::self * Eigen::Vector3d())
       .def(py::self * Rigid3d())
       .def("inverse", static_cast<Rigid3d (*)(const Rigid3d&)>(&Inverse))
@@ -69,7 +73,7 @@ void BindGeometry(py::module& m) {
       .def_readwrite("scale", &Sim3d::scale)
       .def_readwrite("rotation", &Sim3d::rotation)
       .def_readwrite("translation", &Sim3d::translation)
-      .def_property_readonly("matrix", &Sim3d::ToMatrix)
+      .def("matrix", &Sim3d::ToMatrix)
       .def(py::self * Eigen::Vector3d())
       .def(py::self * Sim3d())
       .def("transform_camera_world", &TransformCameraWorld)

--- a/pycolmap/helpers.h
+++ b/pycolmap/helpers.h
@@ -269,6 +269,10 @@ void MakeDataclass(py::class_<T, options...> cls,
   py::implicitly_convertible<py::dict, T>();
   py::implicitly_convertible<py::kwargs, T>();
 
+  cls.def("__copy__", [](const T& self) { return T(self); });
+  cls.def("__deepcopy__",
+          [](const T& self, const py::dict&) { return T(self); });
+
   cls.def(py::pickle(
       [attributes](const T& self) {
         return ConvertToDict(self, attributes, /*recursive=*/false);

--- a/pycolmap/helpers.h
+++ b/pycolmap/helpers.h
@@ -175,7 +175,7 @@ inline std::string CreateSummary(const T& self, bool write_type) {
     if (!after_subsummary) {
       ss << prefix;
     }
-    ss << attribute.template cast<std::string>();
+    ss << name.template cast<std::string>();
     if (py::hasattr(attribute, "summary")) {
       std::string summ = attribute.attr("summary")
                              .attr("__call__")(write_type)

--- a/pycolmap/helpers.h
+++ b/pycolmap/helpers.h
@@ -268,6 +268,16 @@ void MakeDataclass(py::class_<T, options...> cls,
   }));
   py::implicitly_convertible<py::dict, T>();
   py::implicitly_convertible<py::kwargs, T>();
+
+  cls.def(py::pickle(
+      [attributes](const T& self) {
+        return ConvertToDict(self, attributes, /*recursive=*/false);
+      },
+      [cls](const py::dict& dict) {
+        py::object self = cls();
+        self.attr("mergedict").attr("__call__")(dict);
+        return self.cast<T>();
+      }));
 }
 
 // Catch python keyboard interrupts

--- a/pycolmap/scene/camera.h
+++ b/pycolmap/scene/camera.h
@@ -199,5 +199,11 @@ void BindCamera(py::module& m) {
       .def("__deepcopy__",
            [](const Camera& self, const py::dict&) { return Camera(self); })
       .def("__repr__", &PrintCamera);
-  MakeDataclass(PyCamera);
+  MakeDataclass(PyCamera,
+                {"camera_id",
+                 "model",
+                 "width",
+                 "height",
+                 "params",
+                 "has_prior_focal_length"});
 }

--- a/pycolmap/scene/camera.h
+++ b/pycolmap/scene/camera.h
@@ -195,9 +195,6 @@ void BindCamera(py::module& m) {
            "Rescale camera dimensions by given factor and accordingly the "
            "focal length and\n"
            "and the principal point.")
-      .def("__copy__", [](const Camera& self) { return Camera(self); })
-      .def("__deepcopy__",
-           [](const Camera& self, const py::dict&) { return Camera(self); })
       .def("__repr__", &PrintCamera);
   MakeDataclass(PyCamera,
                 {"camera_id",

--- a/pycolmap/scene/image.h
+++ b/pycolmap/scene/image.h
@@ -182,9 +182,9 @@ void BindImage(py::module& m) {
                     &Image::IsRegistered,
                     &Image::SetRegistered,
                     "Whether image is registered in the reconstruction.")
-      .def_property_readonly("num_points2D",
-                             &Image::NumPoints2D,
-                             "Get the number of image points (keypoints).")
+      .def("num_points2D",
+           &Image::NumPoints2D,
+           "Get the number of image points (keypoints).")
       .def_property_readonly(
           "num_points3D",
           &Image::NumPoints3D,

--- a/pycolmap/scene/image.h
+++ b/pycolmap/scene/image.h
@@ -289,9 +289,6 @@ void BindImage(py::module& m) {
           },
           "Project list of image points (with depth) to world coordinate "
           "frame.")
-      .def("__copy__", [](const Image& self) { return Image(self); })
-      .def("__deepcopy__",
-           [](const Image& self, const py::dict&) { return Image(self); })
       .def("__repr__", &PrintImage);
   MakeDataclass(PyImage);
 }

--- a/pycolmap/scene/point2D.h
+++ b/pycolmap/scene/point2D.h
@@ -56,9 +56,6 @@ void BindPoint2D(py::module& m) {
       .def_readwrite("xy", &Point2D::xy)
       .def_readwrite("point3D_id", &Point2D::point3D_id)
       .def("has_point3D", &Point2D::HasPoint3D)
-      .def("__copy__", [](const Point2D& self) { return Point2D(self); })
-      .def("__deepcopy__",
-           [](const Point2D& self, const py::dict&) { return Point2D(self); })
       .def("__repr__", &PrintPoint2D);
   MakeDataclass(PyPoint2D);
 }

--- a/pycolmap/scene/point3D.h
+++ b/pycolmap/scene/point3D.h
@@ -34,9 +34,6 @@ void BindPoint3D(py::module& m) {
       .def_readwrite("color", &Point3D::color)
       .def_readwrite("error", &Point3D::error)
       .def_readwrite("track", &Point3D::track)
-      .def("__copy__", [](const Point3D& self) { return Point3D(self); })
-      .def("__deepcopy__",
-           [](const Point3D& self, const py::dict&) { return Point3D(self); })
       .def("__repr__", [](const Point3D& self) {
         std::stringstream ss;
         ss << "Point3D(xyz=[" << self.xyz.format(vec_fmt) << "], color=["

--- a/pycolmap/scene/track.h
+++ b/pycolmap/scene/track.h
@@ -25,12 +25,6 @@ void BindTrack(py::module& m) {
       .def(py::init<image_t, point2D_t>())
       .def_readwrite("image_id", &TrackElement::image_id)
       .def_readwrite("point2D_idx", &TrackElement::point2D_idx)
-      .def("__copy__",
-           [](const TrackElement& self) { return TrackElement(self); })
-      .def("__deepcopy__",
-           [](const TrackElement& self, const py::dict&) {
-             return TrackElement(self);
-           })
       .def("__repr__", [](const TrackElement& self) {
         return "TrackElement(image_id=" + std::to_string(self.image_id) +
                ", point2D_idx=" + std::to_string(self.point2D_idx) + ")";
@@ -70,9 +64,6 @@ void BindTrack(py::module& m) {
            py::overload_cast<const image_t, const point2D_t>(
                &Track::DeleteElement),
            "Remove TrackElement with (image_id,point2D_idx).")
-      .def("__copy__", [](const Track& self) { return Track(self); })
-      .def("__deepcopy__",
-           [](const Track& self, const py::dict&) { return Track(self); })
       .def("__repr__", [](const Track& self) {
         return "Track(length=" + std::to_string(self.Length()) + ")";
       });

--- a/pycolmap/scene/track.h
+++ b/pycolmap/scene/track.h
@@ -4,6 +4,7 @@
 #include "colmap/util/misc.h"
 #include "colmap/util/types.h"
 
+#include "pycolmap/helpers.h"
 #include "pycolmap/log_exceptions.h"
 
 #include <memory>
@@ -18,8 +19,9 @@ using namespace pybind11::literals;
 namespace py = pybind11;
 
 void BindTrack(py::module& m) {
-  py::class_<TrackElement, std::shared_ptr<TrackElement>>(m, "TrackElement")
-      .def(py::init<>())
+  py::class_<TrackElement, std::shared_ptr<TrackElement>> PyTrackElement(
+      m, "TrackElement");
+  PyTrackElement.def(py::init<>())
       .def(py::init<image_t, point2D_t>())
       .def_readwrite("image_id", &TrackElement::image_id)
       .def_readwrite("point2D_idx", &TrackElement::point2D_idx)
@@ -33,9 +35,10 @@ void BindTrack(py::module& m) {
         return "TrackElement(image_id=" + std::to_string(self.image_id) +
                ", point2D_idx=" + std::to_string(self.point2D_idx) + ")";
       });
+  MakeDataclass(PyTrackElement);
 
-  py::class_<Track, std::shared_ptr<Track>>(m, "Track")
-      .def(py::init<>())
+  py::class_<Track, std::shared_ptr<Track>> PyTrack(m, "Track");
+  PyTrack.def(py::init<>())
       .def(py::init([](const std::vector<TrackElement>& elements) {
         auto track = std::make_shared<Track>();
         track->AddElements(elements);
@@ -73,4 +76,5 @@ void BindTrack(py::module& m) {
       .def("__repr__", [](const Track& self) {
         return "Track(length=" + std::to_string(self.Length()) + ")";
       });
+  MakeDataclass(PyTrack);
 }


### PR DESCRIPTION
- Copy bindings are moved to `MakeDataclass`
- All dataclass objects become pickleable
- To enable this, `todict()` now only exports data attributes
- This requires the following breaking changes:
  - `Rotation3d.quat` becomes a property
  - `{Rigid3d,Sim3d}.matrix` becomes a function
  - `Image.num_points2D` becomes a function
- for `Camera` this would remove useful attributes from the summary (like `param_info`) so we explicitly pass the list of data attributes