### PR TITLE
Autocast numpy.ndarray <-> std::vector<Eigen::Vector>

### DIFF
--- a/pycolmap/main.cc
+++ b/pycolmap/main.cc
@@ -12,7 +12,6 @@
 #include "pycolmap/utils.h"
 
 #include <glog/logging.h>
-#include <pybind11/eigen.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 

--- a/pycolmap/pybind11_extension.h
+++ b/pycolmap/pybind11_extension.h
@@ -6,6 +6,7 @@
 #include <string>
 
 #include <pybind11/cast.h>
+#include <pybind11/eigen.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/pytypes.h>
 #include <pybind11/stl.h>
@@ -53,6 +54,43 @@ struct type_caster<std::string> {
 
   static handle cast(const std::string& s, return_value_policy rvp, handle h) {
     return string_caster<std::string>::cast(s, rvp, h);
+  }
+};
+
+// Autocast from numpy.ndarray to std::vector<Eigen::Vector>
+template <typename Scalar, int Size>
+struct type_caster<std::vector<Eigen::Matrix<Scalar, Size, 1>>> {
+ public:
+  using MatrixType =
+      typename Eigen::Matrix<Scalar, Eigen::Dynamic, Size, Eigen::RowMajor>;
+  using VectorType = typename Eigen::Matrix<Scalar, Size, 1>;
+  using props = EigenProps<MatrixType>;
+  PYBIND11_TYPE_CASTER(std::vector<VectorType>, props::descriptor);
+
+  bool load(handle src, bool) {
+    const auto buf = array::ensure(src);
+    if (!buf) {
+      return false;
+    }
+    const buffer_info info = buf.request();
+    if (info.ndim != 2 || info.shape[1] != Size) {
+      return false;
+    }
+    const size_t num_elements = info.shape[0];
+    value.resize(num_elements);
+    const auto& mat = src.cast<Eigen::Ref<const MatrixType>>();
+    Eigen::Map<MatrixType>(
+        reinterpret_cast<Scalar*>(value.data()), num_elements, Size) = mat;
+    return true;
+  }
+
+  static handle cast(const std::vector<VectorType>& vec,
+                     return_value_policy /* policy */,
+                     handle h) {
+    Eigen::Map<const MatrixType> mat(
+        reinterpret_cast<const Scalar*>(vec.data()), vec.size(), Size);
+    return type_caster<Eigen::Map<const MatrixType>>::cast(
+        mat, return_value_policy::copy, h);
   }
 };
 


### PR DESCRIPTION
For large inputs, the default pybind type caster is much slower than directly copying the underlying memory segment, as hinted by https://github.com/pybind/pybind11/issues/1481.

Test code:
```c++
  using Matrix =
      typename Eigen::Matrix<double, Eigen::Dynamic, 2, Eigen::RowMajor>;
  using Vector = typename Eigen::Vector2d;
  m.def("test_vector", [](const std::vector<Vector>& x) { return x; });
  m.def(
      "test_map",
      [](const Eigen::Ref<Matrix>& x) {
        // Cast to std::vector
        std::vector<Vector> vec(x.rows());
        Eigen::Map<Matrix>(
            reinterpret_cast<double*>(vec.data()), vec.size(), 2) = x;
        // Cast back to Eigen::Matrix
        return Eigen::Map<const Matrix>(
            reinterpret_cast<const double*>(vec.data()), vec.size(), 2);
      },
      py::return_value_policy::copy);
  m.def("test_matrix", [](const Eigen::Ref<Matrix>& x) { return x; });
```
```python
n = 100_000
print(f'{"size":>5}: vector   map      matrix')
for i in [10, 100, 1_000, 10_000]:
    x = np.random.randn(i, 2)
    assert np.all(pycolmap.test_vector(x) == x)
    t_vec = timeit.timeit(lambda: pycolmap.test_vector(x), number=n)/n
    t_map = timeit.timeit(lambda: pycolmap.test_map(x), number=n)/n
    t_mat = timeit.timeit(lambda: pycolmap.test_matrix(x), number=n)/n
    print(f'{i:>5}: {t_vec:.2E} {t_map:.2E} {t_mat:.2E}')
```
Timings (second) without the type caster:
```
 size: vector   map      matrix
   10: 6.95E-06 7.71E-07 4.90E-07
  100: 6.90E-05 7.15E-07 5.28E-07
 1000: 6.82E-04 1.04E-06 5.16E-07
10000: 7.04E-03 5.77E-06 5.03E-07
```
With:
```
 size: vector
   10: 1.02E-06
  100: 1.29E-06
 1000: 2.25E-06
10000: 8.94E-05
```
This is a 100x speedup for 10k inputs. There is still a gap w.r.t direct mapping for C++ -> Python, but I haven't managed to find the source.