### PR TITLE
Extend py::class for non-const readwrite

### DIFF
--- a/pycolmap/geometry/bindings.h
+++ b/pycolmap/geometry/bindings.h
@@ -5,6 +5,7 @@
 
 #include "pycolmap/geometry/homography_matrix.h"
 #include "pycolmap/helpers.h"
+#include "pycolmap/pybind11_extension.h"
 
 #include <sstream>
 
@@ -20,7 +21,7 @@ using namespace pybind11::literals;
 void BindGeometry(py::module& m) {
   BindHomographyGeometry(m);
 
-  py::class_<Eigen::Quaterniond> PyRotation3d(m, "Rotation3d");
+  py::class_ext_<Eigen::Quaterniond> PyRotation3d(m, "Rotation3d");
   PyRotation3d.def(py::init([]() { return Eigen::Quaterniond::Identity(); }))
       .def(py::init<const Eigen::Vector4d&>(),
            "xyzw"_a,
@@ -55,7 +56,7 @@ void BindGeometry(py::module& m) {
   py::implicitly_convertible<py::array, Eigen::Quaterniond>();
   MakeDataclass(PyRotation3d);
 
-  py::class_<Rigid3d> PyRigid3d(m, "Rigid3d");
+  py::class_ext_<Rigid3d> PyRigid3d(m, "Rigid3d");
   PyRigid3d.def(py::init<>())
       .def(py::init<const Eigen::Quaterniond&, const Eigen::Vector3d&>())
       .def(py::init([](const Eigen::Matrix3x4d& matrix) {
@@ -87,7 +88,7 @@ void BindGeometry(py::module& m) {
   py::implicitly_convertible<py::array, Rigid3d>();
   MakeDataclass(PyRigid3d);
 
-  py::class_<Sim3d> PySim3d(m, "Sim3d");
+  py::class_ext_<Sim3d> PySim3d(m, "Sim3d");
   PySim3d.def(py::init<>())
       .def(
           py::init<double, const Eigen::Quaterniond&, const Eigen::Vector3d&>())

--- a/pycolmap/scene/point2D.h
+++ b/pycolmap/scene/point2D.h
@@ -45,7 +45,7 @@ void BindPoint2D(py::module& m) {
         return repr;
       });
 
-  py::class_<Point2D, std::shared_ptr<Point2D>> PyPoint2D(m, "Point2D");
+  py::class_ext_<Point2D, std::shared_ptr<Point2D>> PyPoint2D(m, "Point2D");
   PyPoint2D.def(py::init<>())
       .def(py::init<const Eigen::Vector2d&, size_t>(),
            "xy"_a,

--- a/pycolmap/scene/point3D.h
+++ b/pycolmap/scene/point3D.h
@@ -26,7 +26,7 @@ void BindPoint3D(py::module& m) {
                std::to_string(self.size()) + ")";
       });
 
-  py::class_<Point3D, std::shared_ptr<Point3D>> PyPoint3D(m, "Point3D");
+  py::class_ext_<Point3D, std::shared_ptr<Point3D>> PyPoint3D(m, "Point3D");
   PyPoint3D.def(py::init<>())
       .def_readwrite("xyz", &Point3D::xyz)
       .def_readwrite("color", &Point3D::color)


### PR DESCRIPTION
The getter of [`def_readwrite`](https://github.com/pybind/pybind11/blob/v2.11.1/include/pybind11/pybind11.h#L1670) returns a const reference, which makes numpy arrrays non-writeable. This makes it impossible to write:
```python
p = pycolmap.Point3D(xyz=...)
...
p.xyz += 1
```
This PR transparently makes `def_readwrite` return a non-const reference for some extended classes `py::class_ext_`.