### PR TITLE
Fail to read images and print out image index  in log

### DIFF
--- a/pycolmap/log_exceptions.h
+++ b/pycolmap/log_exceptions.h
@@ -14,6 +14,28 @@ inline std::string ToString(T msg) {
   return std::to_string(msg);
 }
 
+template <typename T>
+inline std::string statusToString(T status) {
+    switch (status) {
+        case T::FAILURE:
+            return "FAILURE";
+        case T::SUCCESS:
+            return "SUCCESS";
+        case T::IMAGE_EXISTS:
+            return "IMAGE_EXISTS";
+        case T::BITMAP_ERROR:
+            return "BITMAP_ERROR";
+        case T::CAMERA_SINGLE_DIM_ERROR:
+            return "CAMERA_SINGLE_DIM_ERROR";
+        case T::CAMERA_EXIST_DIM_ERROR:
+            return "CAMERA_EXIST_DIM_ERROR";
+        case T::CAMERA_PARAM_ERROR:
+            return "CAMERA_PARAM_ERROR";
+        default:
+            return "Unknown";
+    }
+}
+
 inline std::string ToString(std::string msg) { return msg; }
 
 inline std::string ToString(const char* msg) { return std::string(msg); }

--- a/pycolmap/pipeline/images.h
+++ b/pycolmap/pipeline/images.h
@@ -54,7 +54,7 @@ void ImportImages(const std::string& database_path,
     ImageReader::Status status = image_reader.Next(&camera, &image, &bitmap, nullptr);
     if (status != ImageReader::Status::SUCCESS) {
       LOG(WARNING) << "Fail to read image: " << statusToString<ImageReader::Status>(status)
-                   << ", Image Index:" << image_reader.NextIndex()
+                   << ", Image Index:" << image_reader.NextIndex() - 1
                    << "/" << image_reader.NumImages();
       continue;
     }

--- a/pycolmap/pipeline/images.h
+++ b/pycolmap/pipeline/images.h
@@ -51,8 +51,11 @@ void ImportImages(const std::string& database_path,
     Camera camera;
     Image image;
     Bitmap bitmap;
-    if (image_reader.Next(&camera, &image, &bitmap, nullptr) !=
-        ImageReader::Status::SUCCESS) {
+    ImageReader::Status status = image_reader.Next(&camera, &image, &bitmap, nullptr);
+    if (status != ImageReader::Status::SUCCESS) {
+      LOG(WARNING) << "Fail to read image: " << statusToString<ImageReader::Status>(status)
+                   << ", Image Index:" << image_reader.NextIndex()
+                   << "/" << image_reader.NumImages();
       continue;
     }
     DatabaseTransaction database_transaction(&database);


### PR DESCRIPTION
When calling "ImportImages", the images which fail to load should be printed out in log 